### PR TITLE
add SlackClient and Authentik user email endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@slack/web-api": "^7.10.0",
         "axios": "^1.11.0",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
@@ -428,6 +429,53 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.16.0.tgz",
+      "integrity": "sha512-bICnyukvdklXhwxprR3uF1+ZFkTvWTZge4evlCS4G1H1HU6QLY68AcjqzQRymf7/5gNt6Y4OBb4NdviheyZcAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.10.0.tgz",
+      "integrity": "sha512-kT+07JvOqpYH3b/ttVo3iqKIFiHV2NKmD6QUc/F7HrjCgSdSA10zxqi0euXEF2prB49OU7SfjadzQ0WhNc7tiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.11.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -1001,6 +1049,12 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -1666,6 +1720,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -2130,6 +2190,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2177,6 +2243,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-what": {
       "version": "4.1.16",
@@ -2583,6 +2661,62 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2745,6 +2879,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/router": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "GPL-3.0-only",
   "description": "App Dev Club People Portal Server",
   "dependencies": {
+    "@slack/web-api": "^7.10.0",
     "axios": "^1.11.0",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",

--- a/src/clients/AuthentikClient/index.ts
+++ b/src/clients/AuthentikClient/index.ts
@@ -40,6 +40,22 @@ export class AuthentikClient {
         if (!this.AUTHENTIK_TOKEN)
             throw new Error("Authentik Token is Invalid!")
     }
+
+    public getUserEmail = async (userId: string): Promise<string> => {
+        var RequestConfig: any = {
+            ...this.AxiosBaseConfig,
+            method: 'get',
+            url: `/api/v3/core/users/${userId}/`
+        }
+
+        try {
+            const res = await axios.request(RequestConfig)
+            return res.data.email
+        } catch (e) {
+            log.error(AuthentikClient.TAG, "Get User Email Request Failed with Error: ", e)
+            throw new AuthentikClientError("Get User Email Request Failed")
+        }
+    }
     
     public getUserList = async (options: GetUserListOptions): Promise<GetUserListResponse> => {
         var RequestConfig: any = {

--- a/src/clients/AuthentikClient/index.ts
+++ b/src/clients/AuthentikClient/index.ts
@@ -41,22 +41,6 @@ export class AuthentikClient {
             throw new Error("Authentik Token is Invalid!")
     }
 
-    public getUserEmail = async (userId: string): Promise<string> => {
-        var RequestConfig: any = {
-            ...this.AxiosBaseConfig,
-            method: 'get',
-            url: `/api/v3/core/users/${userId}/`
-        }
-
-        try {
-            const res = await axios.request(RequestConfig)
-            return res.data.email
-        } catch (e) {
-            log.error(AuthentikClient.TAG, "Get User Email Request Failed with Error: ", e)
-            throw new AuthentikClientError("Get User Email Request Failed")
-        }
-    }
-    
     public getUserList = async (options: GetUserListOptions): Promise<GetUserListResponse> => {
         var RequestConfig: any = {
             ...this.AxiosBaseConfig,

--- a/src/clients/SlackClient/index.ts
+++ b/src/clients/SlackClient/index.ts
@@ -1,3 +1,102 @@
+import { WebClient } from '@slack/web-api';
+
 export class SlackClient {
+    private slack: WebClient;
+
+    constructor(token = process.env.SLACK_BOT_TOKEN) {
+        if (!token) throw new Error('Missing SLACK_BOT_TOKEN');
+        this.slack = new WebClient(token);
+    }
+
+    // users.lookupByEmail -> boolean (exists?)
+    public async checkIfUserExists(email: string): Promise<boolean> {
+        if (!email) throw new Error('Email is required');
     
+        try {
+        const res = await this.slack.users.lookupByEmail({ email });
+        const anyRes = res as any;
+    
+        // Found
+        if (anyRes?.user?.id) return true;
+    
+        // Not found is a normal case → return false
+        if (anyRes?.ok === false && (anyRes.error === 'users_not_found' || anyRes.error === 'user_not_found')) {
+            return false;
+        }
+    
+        // Slack replied ok:false with another error → surface it
+        if (anyRes?.ok === false) {
+            throw new Error(`Slack API error: ${anyRes.error || 'unknown_error'}`);
+        }
+    
+        // Defensive fallback
+        return false;
+        } catch (e: any) {
+        // If the SDK throws, check for "not found" then rethrow others (auth, network, rate limit)
+        const code = e?.data?.error || e?.code;
+        if (code === 'users_not_found' || code === 'user_not_found') return false;
+        throw e;
+        }
+    }
+    
+
+    public async getUserIdByEmail(email: string): Promise<string> {
+        // Check if email is provided
+        if (!email) throw new Error('Email is required');
+
+        // Check if Slack is configured
+        const res = await this.slack.users.lookupByEmail({ email });
+
+        // Check if the response contains a user ID
+        const id = (res as any)?.user?.id as string | undefined;
+
+        // If no user ID is found, throw an error
+        if (!id) throw new Error('Slack user not found for that email');
+
+        // Return the user ID
+        return id;
+    }
+    
+    
+    public async ensureUserInUserGroup(slackusergroupId: string, slackuserId: string) {
+        // Check if usergroup ID and user ID are provided
+        if (!this.slack) throw new Error('Slack not configured');
+
+        // Check if usergroup ID is provided
+        const list = await this.slack.usergroups.users.list({ usergroup: slackusergroupId, include_disabled: true });
+
+        // Check if the user is already a member of the usergroup
+        const current = new Set((list as any).users || []);
+
+        // If the user is already a member, return early
+        if (current.has(slackuserId)) return { ok: true, already_member: true, users: Array.from(current) };
+        
+        // Add the user to the usergroup
+        current.add(slackuserId);
+
+        // Update the usergroup with the new list of users
+        return this.slack.usergroups.users.update({
+        usergroup: slackusergroupId,
+        users: Array.from(current).join(',')
+        });
+    }
+
+    public async ensureUserInChannel(channelId: string, userId: string) {
+        // Check if channel ID and user ID are provided
+        if (!this.slack) throw new Error('Slack not configured');
+
+        // Check if channel ID is provided
+        try {
+        // Attempt to invite the user to the channel
+        return await this.slack.conversations.invite({ channel: channelId, users: userId });
+        } catch (e: any) {
+        // If the user is already in the channel, return early
+        const code = e?.data?.error || e?.code;
+        if (code === 'already_in_channel' || code === 'already_in_conversation') {
+            return { ok: true, already_in_channel: true };
+        }
+        throw e;
+        }
+    }
+
 }

--- a/src/clients/SlackClient/index.ts
+++ b/src/clients/SlackClient/index.ts
@@ -13,8 +13,8 @@ export class SlackClient {
         if (!email) throw new Error('Email is required');
     
         try {
-        const res = await this.slack.users.lookupByEmail({ email });
-        const anyRes = res as any;
+            const res = await this.slack.users.lookupByEmail({ email });
+            const anyRes = res as any;
     
         // Found
         if (anyRes?.user?.id) return true;

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -55,12 +55,6 @@ export class OrgController extends Controller {
         return await this.authentikClient.getGroupsList(options)
     }
 
-    @Get("emails/{userId}")
-    @SuccessResponse(200)
-    async getUserEmail(@Path() userId: string): Promise<string> {
-        return await this.authentikClient.getUserEmail(userId)
-    }
-
     @Get("teams/{teamId}")
     @SuccessResponse(200)
     async getTeamInfo(@Path() teamId: string): Promise<APITeamInfoResponse> {

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -55,6 +55,12 @@ export class OrgController extends Controller {
         return await this.authentikClient.getGroupsList(options)
     }
 
+    @Get("emails/{userId}")
+    @SuccessResponse(200)
+    async getUserEmail(@Path() userId: string): Promise<string> {
+        return await this.authentikClient.getUserEmail(userId)
+    }
+
     @Get("teams/{teamId}")
     @SuccessResponse(200)
     async getTeamInfo(@Path() teamId: string): Promise<APITeamInfoResponse> {


### PR DESCRIPTION
Added a SlackClient wrapper around @slack/web-api with getUserIdByEmail, checkIfUserExists, ensureUserInUserGroup, and ensureUserInChannel.

Exposed GET /api/org/emails/{userId} in OrgController to return a user’s email via Authentik.

Implemented AuthentikClient.getUserEmail(userId) to GET /api/v3/core/users/{userId}/ and return res.data.email.