### PR TITLE
Feature/reviews

### DIFF
--- a/src/clients/PeoplePortalClient/index.ts
+++ b/src/clients/PeoplePortalClient/index.ts
@@ -57,6 +57,11 @@ export class PeoplePortalClient implements SharedResourceClient {
             friendlyName: "Allow Member Management",
             description: "Enabling this allows people in this subteam to add & remove members to your team",
         },
+
+        "corp:reviewaccess": {
+            friendlyName: "Allow Internal Review Access",
+            description: "Enabling this allows people in this subteam to write internal reviews on other members of this team.",
+        },
     }
 
     async init(): Promise<void> {

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -16,10 +16,11 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import * as express from 'express'
+import * as express from 'express';
 import path from 'path';
+import { Error, FlattenMaps, HydratedDocument, Types } from 'mongoose';
 import { Request, Body, Controller, Get, Patch, Path, Post, Queries, Route, SuccessResponse, Put, Security, Delete, Tags, Query } from "tsoa";
-import { AddGroupMemberRequest, GetGroupInfoResponse, GetTeamsListResponse, GetUserListOptions, GetUserListResponse, RemoveGroupMemberRequest, SeasonType, TeamType, UserInformationBrief, GetTeamsForUsernameResponse, AuthentikClientError, CreateUserRequest, ServiceSeasonType, AuthentikClientErrorType } from "../clients/AuthentikClient/models";
+import { AddGroupMemberRequest, GetGroupInfoResponse, GetTeamsListResponse, GetUserListOptions, GetUserListResponse, RemoveGroupMemberRequest, SeasonType, TeamType, UserInformationBrief, GetTeamsForUsernameResponse, AuthentikClientError, CreateUserRequest, ServiceSeasonType, AuthentikClientErrorType, TeamAttributeDefinition, TeamInformationBrief } from "../clients/AuthentikClient/models";
 import { AuthentikClient } from "../clients/AuthentikClient";
 import { Invite } from "../models/Invites";
 import { EmailClient } from "../clients/EmailClient";
@@ -36,12 +37,16 @@ import { BindleController, EnabledBindlePermissions } from '../controllers/Bindl
 import { AuthorizedUser } from '../clients/OpenIdClient';
 import { executiveAuthVerify } from '../auth';
 import { TeamCreationRequest, TeamCreationRequestStatus, ITeamCreationRequest } from '../models/TeamCreationRequest';
-import { CustomValidationError, SharedResourcesError } from '../utils/errors';
+import { CustomValidationError, ResourceAccessError, SharedResourcesError } from '../utils/errors';
 import { ExpressRequestBindleExtension } from '../types/express';
 import { validateS3FileSignature, FILE_SIGNATURES } from '../utils/s3-validation';
 import { signAvatarUrl } from '../utils/avatars';
 import MarkdownIt from "markdown-it";
 import zxcvbn from 'zxcvbn';
+import { IUserReview, UserReview } from '../models/UserReview';
+import { stringify } from 'querystring';
+
+type DocumentJSON<T> = FlattenMaps<T> & Required<{ _id: Types.ObjectId; }> & { __v: number; };
 
 export interface EnabledRootSettings {
     [key: string]: boolean
@@ -54,6 +59,42 @@ export interface RootTeamSettingMap {
 export interface RootTeamSettingInfo {
     friendlyName: string,
     description: string,
+}
+
+interface APIGetCommonTeamsResponse {
+    teams: TeamInformationBrief[];
+}
+
+interface APIGetReviewResponse {
+    review: DocumentJSON<IUserReview> | null;
+}
+
+interface APIGetReviewsOptions {
+    before?: Date;
+    after?: Date;
+    teamId?: Date;
+    sortBy?: "updatedAt" | "rating";
+    ascending?: boolean;
+    offset?: number;
+    limit?: number;
+}
+
+interface APIGetReviewsResponse {
+    reviews: DocumentJSON<IUserReview>[];
+    pagination: {
+        totalReviews: number;
+    }
+}
+
+interface APICreateReviewRequest {
+    rating: number;
+    title: string;
+    content: string;
+    teamId: string;
+}
+
+interface APICreateReviewResponse {
+    review: DocumentJSON<IUserReview>;
 }
 
 /* Define Request Interfaces */
@@ -241,6 +282,343 @@ export class OrgController extends Controller {
 
         return {
             ...authentikUserInfo
+        }
+    }
+
+    /**
+     * Gets all common teams between the requesting user and
+     * another person given their id.
+     * 
+     * @param req express Request object
+     * @param personId id of the person to get common teams.
+     * @returns APIGetCommonTeamsResponse
+     */
+    @Get("people/{personId}/commonteams")
+    @Tags("People Management")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async getCommonTeams(
+        @Request() req: express.Request,
+        @Path() personId: number
+    ): Promise<APIGetCommonTeamsResponse>
+    {
+        // Get user info
+        const userInfo = await this.authentikClient.getUserInfo(personId)
+            .catch((e) => { 
+                throw new ResourceAccessError(400, `Failed to fetch user info: ${e}`) 
+            });
+        
+        // Get common teams
+        const authorizedUser = req.session.authorizedUser!;
+
+        const [userTeams, requesterTeams] = await Promise.all([
+            await this.authentikClient.getRootTeamsForUsername(userInfo.username)
+                .catch((e) => { 
+                    throw new ResourceAccessError(400, `Failed to fetch user teams: ${e}`) 
+                }),
+            await this.authentikClient.getRootTeamsForUsername(authorizedUser.username)
+                .catch((e) => { 
+                    throw new ResourceAccessError(400, `Failed to fetch user teams: ${e}`) 
+                })
+        ]);
+        
+        const commonTeams = userTeams.teams.filter((t) => 
+            requesterTeams.teams.find((team) => team.pk === t.pk) !== undefined
+        );
+
+        // Return team info
+        return { teams: commonTeams };
+    }
+
+    /**
+     * Gets the requestor's review (if it exists) of a user
+     * for a certain team.
+     * 
+     * @param req express Request object
+     * @param personId id of the target person
+     * @param teamId id of the target team
+     * @returns APIGetReviewResponse
+     */
+    @Get("people/{personId}/reviews/{teamId}")
+    @Tags("People Management")
+    @SuccessResponse(200)
+    @Security("bindles", ["corp:reviewaccess"])
+    async getReview(
+        @Request() req: express.Request,
+        @Path() personId: number,
+        @Path() teamId: string
+    ): Promise<APIGetReviewResponse> {
+        // 0. Ensure requester and user id are not equal
+        if (req.session.authorizedUser!.pk === personId) {
+            throw new CustomValidationError(403, "Can not access own reviews.");
+        }
+        // 1. Ensure user exists
+        const userInfo = await this.authentikClient.getUserInfo(personId)
+            .catch((e) => { 
+                throw new ResourceAccessError(400, `Failed to fetch user info: ${e}`) 
+            });
+
+        // 2. Ensure user is in the target team
+        let userTeams: GetTeamsForUsernameResponse;
+        try {
+            userTeams = await this.authentikClient.getRootTeamsForUsername(userInfo.username);
+        } catch (e) {
+            console.error(e);
+            throw new ResourceAccessError(500, "Failed to get user team membership");
+        }
+
+        if (userTeams.teams.findIndex((team) => team.pk === teamId) === -1) {
+            // User is not in target team.
+            throw new CustomValidationError(403, "User is not in target team.");
+        }
+
+        // 3. Find document and return it.
+        try { 
+            const review = await UserReview.findOne({
+                userId: personId,
+                creatorId: req.session.authorizedUser!.pk,
+                teamId: teamId,
+            }).lean().exec();
+            return { review: review };
+        } catch (e) {
+            console.error(e);
+            throw new ResourceAccessError(500, "Failed to fetch review");
+        }
+    }
+
+    @Get("people/{personId}/reviews")
+    @Tags("People Management")
+    @SuccessResponse(200)
+    @Security("executive")
+    async getReviews(
+        @Request() req: express.Request,
+        @Path() personId: number,
+        @Queries() options: APIGetReviewsOptions
+    ): Promise<APIGetReviewsResponse> {
+        
+        const limit = Math.min(100, options.limit ?? 10);
+        if (limit < 1) {
+            throw new CustomValidationError(400, "Limit must be a positive integer.");
+        }
+
+        // Build query
+        const filters: Record<string, any> = {
+            userId: personId,
+            ...(options.before !== undefined || options.after !== undefined) && {
+                updatedAt: {
+                    ...(options.before !== undefined && { $lte: options.before }),
+                    ...(options.after !== undefined && { $gte: options.after }),
+                }
+            },
+            ...(options.teamId !== undefined && { teamId: options.teamId }),
+        };
+
+        let query = UserReview.find(filters);
+
+        if (options.sortBy !== undefined) {
+            const ascending = (options.ascending ?? true) ? 'asc' : 'desc';
+            query = query.sort({ [options.sortBy]: ascending });
+        }
+
+        query = query.skip(options.offset ?? 0).limit(limit);
+
+        try {
+            const results = await query.lean().exec();
+            const totalReviews = await UserReview.countDocuments(filters).lean().exec();
+            return { reviews: results, pagination: { totalReviews: totalReviews } };
+
+        } catch (e) {
+            throw new ResourceAccessError(500, `Failed to fetch reviews: ${e}`);
+        }
+    }
+
+    /**
+     * Write an internal review for a person. the requestor and person
+     * must both be in body.teamId and the requestor must have the
+     * corp:reviewaccess bindle in that team.
+     * 
+     * @param req express Request object
+     * @param personId pk of the person being reviewed
+     * @param body APICreateReviewRequest instance
+     * @returns APICreateReviewResponse instance
+     */
+    @Post("people/{personId}/reviews")
+    @Tags("People Management")
+    @SuccessResponse(201)
+    // First scope is teamId path (see bindlesAuthVerify)
+    @Security("bindles", ["body.teamId", "corp:reviewaccess"])
+    async writeReview(
+        @Request() req: express.Request,
+        @Path() personId: number,
+        @Body() body: APICreateReviewRequest
+    ): Promise<APICreateReviewResponse> {
+        // User refers to the personId, requester refers to the user making the request.
+
+        // 0. Ensure user and requester aren't the same
+        if (personId === req.session.authorizedUser!.pk) {
+            throw new CustomValidationError(403, "You can not review yourself.");
+        }
+
+        // 1. Ensure user exists
+        const userInfo = await this.authentikClient.getUserInfo(personId)
+            .catch((e) => { throw new ResourceAccessError(400, `Failed to fetch user info: ${e}`) });
+
+        // 2. Ensure user is in the target team
+        let userTeams: GetTeamsForUsernameResponse;
+        try {
+            userTeams = await this.authentikClient.getRootTeamsForUsername(userInfo.username);
+        } catch (e) {
+            console.error(e);
+            throw new ResourceAccessError(500, "Failed to get user team membership");
+        }
+
+        if (userTeams.teams.findIndex((team) => team.pk === body.teamId) === -1) {
+            // User is not in target team.
+            throw new CustomValidationError(403, "User is not in target team.");
+        }
+
+        // 3. Requester is authorized to write the review. Check if a review was already made for this team.
+        try {
+            const existingReview = await UserReview.findOne({
+                userId: personId,
+                creatorId: req.session.authorizedUser!.pk,
+                teamId: body.teamId,
+            }).lean().exec();
+            if (existingReview !== null) {
+                throw new CustomValidationError(400, "Review already created.");
+            }
+        } catch (e) {
+            console.error(e);
+            if (e instanceof CustomValidationError) {
+                throw e;
+            }
+            throw new ResourceAccessError(500, "Failed to fetch review.");
+        }
+        
+        // 4. Create review.
+        let review: HydratedDocument<IUserReview>;
+        try {
+            review = await UserReview.create({
+                userId: personId,
+                creatorId: req.session.authorizedUser!.pk,
+                ...body,
+            });
+        } catch (e) {
+            if (e instanceof Error.ValidationError) {
+                throw new CustomValidationError(400, `Invalid Review: ${e}`);
+            }
+            console.error(e);
+            throw new ResourceAccessError(500, "Failed to create review");
+        }
+
+        return { review: review.toJSON() };
+    }   
+
+    /**
+     * Edit an existing review for a person. The requestor must
+     * have the corp:reviewaccess bindle in the team being requested.
+     * Only permits the review author to edit the review.
+     * 
+     * @param req express Request object
+     * @param personId pk of the person being reviewed
+     * @param reviewId ObjectID of the review
+     * @param body APICreateReviewRequest instance
+     * @returns APICreateReviewResponse instance
+     */
+    @Put("people/{personId}/reviews/{reviewId}")
+    @Tags("People Management")
+    @SuccessResponse(200)
+    // First scope is teamId path (see bindlesAuthVerify)
+    @Security("bindles", ["body.teamId", "corp:reviewaccess"])
+    async editReview(
+        @Request() req: express.Request,
+        @Path() personId: number,
+        @Path() reviewId: string,
+        @Body() body: APICreateReviewRequest
+    ): Promise<APICreateReviewResponse> {
+        // 0. Ensure user and requester aren't the same
+        if (personId === req.session.authorizedUser!.pk) {
+            throw new CustomValidationError(403, "You can not review yourself.");
+        }
+
+        // 1. Get Review
+        const review = await UserReview.findById(reviewId).exec()
+            .catch((e) => { throw new ResourceAccessError(500, `Failed to fetch review: ${e}`)});
+
+        if (review === null) {
+            throw new CustomValidationError(404, "Review does not exist");
+        }
+
+        // 2. Validation Checks
+        // Ensure creator and user ids match
+        if (review.creatorId !== req.session.authorizedUser!.pk) {
+            // Return does not exist for obscurity
+            throw new CustomValidationError(404, "Review does not exist");
+        }
+        if (review.userId !== personId) {
+            throw new CustomValidationError(400, "User ID does not match");
+        }
+        
+        // Ensure teamId matches review
+        if (review.teamId !== body.teamId) {
+            throw new CustomValidationError(400, "Team ID does not match.");
+        }
+
+        // 3. Update Review
+        review.rating = body.rating;
+        review.title = body.title;
+        review.content = body.content;
+        await review.save();
+
+        // 4. Return updated document
+        return { review: review.toJSON() };
+    }
+
+    /**
+     * Delete an existing review for a person.
+     * Permites either the author or any executives to 
+     * delete the review.
+     * 
+     * @param req express Request object
+     * @param personId pk of the person being reviewed
+     * @param reviewId ObjectID of the review
+     * @returns void
+     */
+    @Delete("people/{personId}/reviews/{reviewId}")
+    @Tags("People Management")
+    @SuccessResponse(204)
+    @Security("oidc")
+    async deleteReview(
+        @Request() req: express.Request,
+        @Path() personId: number,
+        @Path() reviewId: string
+    ) {
+        // 1. Get Review
+        const review = await UserReview.findById(reviewId).exec()
+            .catch((e) => { throw new ResourceAccessError(500, `Failed to fetch review: ${e}`)});
+
+        if (review === null) {
+            throw new CustomValidationError(404, "Review does not exist");
+        }
+
+        // 2. Validation Checks
+        // Ensure creator and user ids match
+        if (review.creatorId !== req.session.authorizedUser!.pk) {
+            // Allow exec/superuser to delete other's reviews
+            if (!executiveAuthVerify(req, [], true)) {
+                // Return does not exist for obscurity
+                throw new CustomValidationError(404, "Review does not exist");
+            }
+        }
+        if (review.userId !== personId) {
+            throw new CustomValidationError(400, "User ID does not match");
+        }
+        
+        // 3. Delete Review
+        try {
+            await review.deleteOne().exec();
+        } catch (e) {
+            throw new ResourceAccessError(500, `Failed to delete review: ${e}`);
         }
     }
 

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -315,11 +315,11 @@ export class OrgController extends Controller {
         const authorizedUser = req.session.authorizedUser!;
 
         const [userTeams, requesterTeams] = await Promise.all([
-            await this.authentikClient.getRootTeamsForUsername(userInfo.username)
+            this.authentikClient.getRootTeamsForUsername(userInfo.username)
                 .catch((e) => { 
                     throw new ResourceAccessError(400, `Failed to fetch user teams: ${e}`) 
                 }),
-            await this.authentikClient.getRootTeamsForUsername(authorizedUser.username)
+            this.authentikClient.getRootTeamsForUsername(authorizedUser.username)
                 .catch((e) => { 
                     throw new ResourceAccessError(400, `Failed to fetch user teams: ${e}`) 
                 })
@@ -389,6 +389,17 @@ export class OrgController extends Controller {
         }
     }
 
+
+    /**
+     * Gets a list of reviews made on the given person. Requires
+     * executive permissions. Options can be given to filter,
+     * sort, and attain aggregate data such as average rating
+     * and total review count (with the filters applied).
+     * 
+     * @param personId pk of the person.
+     * @param options APIGetReviewsOptions
+     * @returns APIGetReviewsResponse
+     */
     @Get("people/{personId}/reviews")
     @Tags("People Management")
     @SuccessResponse(200)
@@ -406,7 +417,7 @@ export class OrgController extends Controller {
         }
 
         if (options.before && options.after && options.before.getTime() < options.after.getTime()) {
-            throw new CustomValidationError(400, "'before' can not be after 'after'.");
+            throw new CustomValidationError(400, "The 'before' timestamp can not be before the 'after' timestamp.");
         }
 
         // Build query
@@ -422,7 +433,7 @@ export class OrgController extends Controller {
         };
 
         // Just return the aggregate data
-        if (limit == 0) {
+        if (limit === 0) {
             if (options.getAggregateData === false) {
                 return { reviews: [] };
             }
@@ -463,8 +474,8 @@ export class OrgController extends Controller {
             }
 
             const [results, aggregateResult] = await Promise.all([
-                await query.lean().exec(),
-                await UserReview.aggregate([
+                query.lean().exec(),
+                UserReview.aggregate([
                     { $match: filters },
                     { $facet: { stats: [{ $group: {
                         _id: null,

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -41,10 +41,8 @@ import { CustomValidationError, ResourceAccessError, SharedResourcesError } from
 import { ExpressRequestBindleExtension } from '../types/express';
 import { validateS3FileSignature, FILE_SIGNATURES } from '../utils/s3-validation';
 import { signAvatarUrl } from '../utils/avatars';
-import MarkdownIt from "markdown-it";
 import zxcvbn from 'zxcvbn';
 import { IUserReview, UserReview } from '../models/UserReview';
-import { stringify } from 'querystring';
 
 type DocumentJSON<T> = FlattenMaps<T> & Required<{ _id: Types.ObjectId; }> & { __v: number; };
 
@@ -73,17 +71,22 @@ interface APIGetReviewsOptions {
     before?: Date;
     after?: Date;
     teamId?: Date;
+
     sortBy?: "updatedAt" | "rating";
     ascending?: boolean;
+
     offset?: number;
     limit?: number;
+
+    getAggregateData?: boolean;
 }
 
 interface APIGetReviewsResponse {
     reviews: DocumentJSON<IUserReview>[];
-    pagination: {
-        totalReviews: number;
-    }
+    aggregateData?: {
+        totalReviews: number,
+        averageRating: number
+    };
 }
 
 interface APICreateReviewRequest {
@@ -391,14 +394,19 @@ export class OrgController extends Controller {
     @SuccessResponse(200)
     @Security("executive")
     async getReviews(
-        @Request() req: express.Request,
         @Path() personId: number,
         @Queries() options: APIGetReviewsOptions
     ): Promise<APIGetReviewsResponse> {
         
+        // Max 100 reviews returned.
         const limit = Math.min(100, options.limit ?? 10);
-        if (limit < 1) {
-            throw new CustomValidationError(400, "Limit must be a positive integer.");
+
+        if (limit < 0) {
+            throw new CustomValidationError(400, "Limit can not be negative.");
+        }
+
+        if (options.before && options.after && options.before.getTime() < options.after.getTime()) {
+            throw new CustomValidationError(400, "'before' can not be after 'after'.");
         }
 
         // Build query
@@ -413,6 +421,32 @@ export class OrgController extends Controller {
             ...(options.teamId !== undefined && { teamId: options.teamId }),
         };
 
+        // Just return the aggregate data
+        if (limit == 0) {
+            if (options.getAggregateData === false) {
+                return { reviews: [] };
+            }
+            try {
+                const result = await UserReview.aggregate([
+                    { $match: filters },
+                    { $facet: {
+                        stats: [
+                            { $group: {
+                                _id: null,
+                                average: { $avg: "$rating" },
+                                count: { $sum: 1 } 
+                            }}
+                        ]
+                    }}
+                ]).exec();
+                const { average, count } = result[0]?.stats[0] ?? { average: 0, count: 0 };
+
+                return { reviews: [], aggregateData: { totalReviews: count, averageRating: average } };
+            } catch (e) {
+                throw new ResourceAccessError(500, `Failed to fetch reviews: ${e}`);
+            }
+        }
+
         let query = UserReview.find(filters);
 
         if (options.sortBy !== undefined) {
@@ -423,9 +457,25 @@ export class OrgController extends Controller {
         query = query.skip(options.offset ?? 0).limit(limit);
 
         try {
-            const results = await query.lean().exec();
-            const totalReviews = await UserReview.countDocuments(filters).lean().exec();
-            return { reviews: results, pagination: { totalReviews: totalReviews } };
+            if (options.getAggregateData === false) {
+                const results = await query.lean().exec();
+                return { reviews: results };
+            }
+
+            const [results, aggregateResult] = await Promise.all([
+                await query.lean().exec(),
+                await UserReview.aggregate([
+                    { $match: filters },
+                    { $facet: { stats: [{ $group: {
+                        _id: null,
+                        average: { $avg: "$rating" },
+                        count: { $sum: 1 } 
+                    }}]}}
+                ]).exec()
+            ]);
+
+            const { average, count } = aggregateResult[0]?.stats[0] ?? { average: 0, count: 0 };
+            return { reviews: results, aggregateData: { totalReviews: count, averageRating: average } };
 
         } catch (e) {
             throw new ResourceAccessError(500, `Failed to fetch reviews: ${e}`);

--- a/src/models/UserReview.ts
+++ b/src/models/UserReview.ts
@@ -1,0 +1,77 @@
+/**
+  People Portal Server
+  Copyright (C) 2026  Atheesh Thirumalairajan
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Schema, model, Document } from 'mongoose';
+
+const MAX_TITLE_LENGTH = 150;
+const MIN_REVIEW_LENGTH = 50;
+const MAX_REVIEW_LENGTH = 2000;
+
+
+export interface IUserReview extends Document {
+  userId: number;
+  creatorId: number;
+  teamId: string;   // The review will be regarding the user's work under this team
+  rating: number;
+  title: string;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const userReviewSchema = new Schema<IUserReview>({
+  userId: {
+    type: Number,
+    required: true,
+    index: true,
+  },
+  creatorId: {
+    type: Number,
+    required: true,
+  },
+  teamId: {
+    type: String,
+    required: true,
+  },
+  rating: {
+    type: Number,
+    required: true,
+    validate: {
+        validator: (rating: number) => rating >= 1 && rating <= 5 && Number.isInteger(rating * 10),
+        message: "Rating must be between 1 and 5, and can only have up to 1 decimal place."
+    }
+  },
+  title: {
+    type: String,
+    required: true,
+    validate: {
+        validator: (title: string) => title.length > 0 && title.length <= MAX_TITLE_LENGTH,
+        message: `Title must be non-empty and a maximum of ${MAX_TITLE_LENGTH} characters long.`
+    }
+  },
+  content: {
+    type: String,
+    required: true,
+    validate: {
+        validator: (content: string) => content.length > MIN_REVIEW_LENGTH && content.length <= MAX_REVIEW_LENGTH,
+        message: `Content must be between ${MIN_REVIEW_LENGTH} and ${MAX_REVIEW_LENGTH} characters long.`
+    }
+  },
+}, { timestamps: true });
+
+export const UserReview = model<IUserReview>('UserReview', userReviewSchema);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -216,7 +216,7 @@ const models: TsoaRoute.Models = {
         "dataType": "refObject",
         "properties": {
             "reviews": {"dataType":"array","array":{"dataType":"refAlias","ref":"DocumentJSON_IUserReview_"},"required":true},
-            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"totalReviews":{"dataType":"double","required":true}},"required":true},
+            "aggregateData": {"dataType":"nestedObjectLiteral","nestedProperties":{"averageRating":{"dataType":"double","required":true},"totalReviews":{"dataType":"double","required":true}}},
         },
         "additionalProperties": false,
     },
@@ -231,6 +231,7 @@ const models: TsoaRoute.Models = {
             "ascending": {"dataType":"boolean"},
             "offset": {"dataType":"double"},
             "limit": {"dataType":"double"},
+            "getAggregateData": {"dataType":"boolean"},
         },
         "additionalProperties": false,
     },
@@ -1014,7 +1015,6 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsOrgController_getReviews: Record<string, TsoaRoute.ParameterSchema> = {
-                req: {"in":"request","name":"req","required":true,"dataType":"object"},
                 personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
                 options: {"in":"queries","name":"options","required":true,"ref":"APIGetReviewsOptions"},
         };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -176,6 +176,84 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIGetCommonTeamsResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "teams": {"dataType":"array","array":{"dataType":"refObject","ref":"TeamInformationBrief"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "mongoose.FlattenMaps_IUserReview_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "mongoose.Types.ObjectId": {
+        "dataType": "refAlias",
+        "type": {"dataType":"string","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Required___id-mongoose.Types.ObjectId__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"_id":{"ref":"mongoose.Types.ObjectId","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DocumentJSON_IUserReview_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"intersection","subSchemas":[{"ref":"mongoose.FlattenMaps_IUserReview_"},{"ref":"Required___id-mongoose.Types.ObjectId__"},{"dataType":"nestedObjectLiteral","nestedProperties":{"__v":{"dataType":"double","required":true}}}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIGetReviewResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "review": {"dataType":"union","subSchemas":[{"ref":"DocumentJSON_IUserReview_"},{"dataType":"enum","enums":[null]}],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIGetReviewsResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "reviews": {"dataType":"array","array":{"dataType":"refAlias","ref":"DocumentJSON_IUserReview_"},"required":true},
+            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"totalReviews":{"dataType":"double","required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIGetReviewsOptions": {
+        "dataType": "refObject",
+        "properties": {
+            "before": {"dataType":"datetime"},
+            "after": {"dataType":"datetime"},
+            "teamId": {"dataType":"datetime"},
+            "sortBy": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["updatedAt"]},{"dataType":"enum","enums":["rating"]}]},
+            "ascending": {"dataType":"boolean"},
+            "offset": {"dataType":"double"},
+            "limit": {"dataType":"double"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APICreateReviewResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "review": {"ref":"DocumentJSON_IUserReview_","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APICreateReviewRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "rating": {"dataType":"double","required":true},
+            "title": {"dataType":"string","required":true},
+            "content": {"dataType":"string","required":true},
+            "teamId": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "GetTeamsForUsernameResponse": {
         "dataType": "refObject",
         "properties": {
@@ -642,11 +720,6 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Required___id-mongoose.Types.ObjectId__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ATSSubteamConfigRequest": {
         "dataType": "refObject",
         "properties": {
@@ -700,11 +773,6 @@ const models: TsoaRoute.Models = {
             "notes": {"dataType":"string"},
         },
         "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "mongoose.Types.ObjectId": {
-        "dataType": "refAlias",
-        "type": {"dataType":"string","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ATSUpdateApplicationStageRequest": {
@@ -874,6 +942,204 @@ export function RegisterRoutes(app: Router) {
                 next,
                 validatedArgs,
                 successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOrgController_getCommonTeams: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
+        };
+        app.get('/api/org/people/:personId/commonteams',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(OrgController)),
+            ...(fetchMiddlewares<RequestHandler>(OrgController.prototype.getCommonTeams)),
+
+            async function OrgController_getCommonTeams(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOrgController_getCommonTeams, request, response });
+
+                const controller = new OrgController();
+
+              await templateService.apiHandler({
+                methodName: 'getCommonTeams',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOrgController_getReview: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+        };
+        app.get('/api/org/people/:personId/reviews/:teamId',
+            authenticateMiddleware([{"bindles":["corp:reviewaccess"]}]),
+            ...(fetchMiddlewares<RequestHandler>(OrgController)),
+            ...(fetchMiddlewares<RequestHandler>(OrgController.prototype.getReview)),
+
+            async function OrgController_getReview(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOrgController_getReview, request, response });
+
+                const controller = new OrgController();
+
+              await templateService.apiHandler({
+                methodName: 'getReview',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOrgController_getReviews: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
+                options: {"in":"queries","name":"options","required":true,"ref":"APIGetReviewsOptions"},
+        };
+        app.get('/api/org/people/:personId/reviews',
+            authenticateMiddleware([{"executive":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(OrgController)),
+            ...(fetchMiddlewares<RequestHandler>(OrgController.prototype.getReviews)),
+
+            async function OrgController_getReviews(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOrgController_getReviews, request, response });
+
+                const controller = new OrgController();
+
+              await templateService.apiHandler({
+                methodName: 'getReviews',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOrgController_writeReview: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
+                body: {"in":"body","name":"body","required":true,"ref":"APICreateReviewRequest"},
+        };
+        app.post('/api/org/people/:personId/reviews',
+            authenticateMiddleware([{"bindles":["body.teamId","corp:reviewaccess"]}]),
+            ...(fetchMiddlewares<RequestHandler>(OrgController)),
+            ...(fetchMiddlewares<RequestHandler>(OrgController.prototype.writeReview)),
+
+            async function OrgController_writeReview(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOrgController_writeReview, request, response });
+
+                const controller = new OrgController();
+
+              await templateService.apiHandler({
+                methodName: 'writeReview',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOrgController_editReview: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
+                reviewId: {"in":"path","name":"reviewId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"ref":"APICreateReviewRequest"},
+        };
+        app.put('/api/org/people/:personId/reviews/:reviewId',
+            authenticateMiddleware([{"bindles":["body.teamId","corp:reviewaccess"]}]),
+            ...(fetchMiddlewares<RequestHandler>(OrgController)),
+            ...(fetchMiddlewares<RequestHandler>(OrgController.prototype.editReview)),
+
+            async function OrgController_editReview(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOrgController_editReview, request, response });
+
+                const controller = new OrgController();
+
+              await templateService.apiHandler({
+                methodName: 'editReview',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOrgController_deleteReview: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                personId: {"in":"path","name":"personId","required":true,"dataType":"double"},
+                reviewId: {"in":"path","name":"reviewId","required":true,"dataType":"string"},
+        };
+        app.delete('/api/org/people/:personId/reviews/:reviewId',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(OrgController)),
+            ...(fetchMiddlewares<RequestHandler>(OrgController.prototype.deleteReview)),
+
+            async function OrgController_deleteReview(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOrgController_deleteReview, request, response });
+
+                const controller = new OrgController();
+
+              await templateService.apiHandler({
+                methodName: 'deleteReview',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 204,
               });
             } catch (err) {
                 return next(err);


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
Adds the ability to write, view, edit, and delete internal reviews for people in PeoplePortal. Writing reviews is only permitted to executives and users with the corp:reviewaccess bindle if these cases are met:

The reviewer and user must share teams (root teams, not subteams)
The reviewer has the bindle in at least one of these shared teams.
A user with the bindle can write one review for each shared team the bindle applies to, per person.
Executives can view and delete reviews written by other people. An average of all ratings will also be visible to execs visiting the user page. Otherwise, users can only view their own reviews if they have the review access bindle.

Ratings from 1-5 (up to 1 decimal) come attached with each review. Executives can see average ratings of a user.


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Chore / dependency update

## Testing
<!-- How did you test this? What should reviewers check? -->
Tested endpoints with users with varying permissions using test users in authentik to test endpoint security and authorization.
Ensured that creating, editing, and deleting reviews was reflected in MongoDB.
Tested get endpoints to ensure that reviews were correctly being returned.


## Screenshots
<!-- If UI changes, include before/after screenshots -->
See associated PR in the PeoplePortalUI repository.

## Checklist
- [x] Self-reviewed my own code
- [x] No console.log / debug statements left in
- [x] Tested locally
