### PR TITLE
Feature/team meetings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/
 dist/
 node_modules/
+docs/site/
+docs/.venv/

--- a/src/clients/AuthentikClient/index.ts
+++ b/src/clients/AuthentikClient/index.ts
@@ -89,7 +89,9 @@ export class AuthentikClient {
                         teamType: TeamType.SERVICE,
                         seasonType: ServiceSeasonType.ROLLING,
                         seasonYear: new Date().getFullYear(),
-                        description: rootTeamConfig.description
+                        description: rootTeamConfig.description,
+                        teamStartDate: new Date().toISOString().slice(0, 10),
+                        teamEndDate: new Date().toISOString().slice(0, 10),
                     }
                 })
 
@@ -124,7 +126,9 @@ export class AuthentikClient {
                             teamType: TeamType.CORPORATE,
                             seasonType: ServiceSeasonType.ROLLING,
                             seasonYear: new Date().getFullYear(),
-                            description: subTeam.description
+                            description: subTeam.description,
+                            teamStartDate: new Date().toISOString().slice(0, 10),
+                            teamEndDate: new Date().toISOString().slice(0, 10),
                         }
                     })
                     subTeamPk = createdSubTeam.pk;
@@ -566,14 +570,14 @@ export class AuthentikClient {
     }
 
     /**
-     * Validates and updates group information (Friendly Name & Description).
+     * Validates and updates group information (Friendly Name, Description, Team Dates).
      * 
      * @param teamId Target Team ID
      * @param conf Configuration object containing potential updates
      */
     public updateGroupInformation = async (teamId: string, conf: { [key: string]: string | undefined }) => {
-        /* Strictly restrict updates to only name and description to prevent attribute pollution */
-        const allowedFields = ["friendlyName", "description"];
+        /* Strictly restrict updates to allowed fields to prevent attribute pollution */
+        const allowedFields = ["friendlyName", "description", "teamStartDate", "teamEndDate"];
         const filteredConf: any = {};
 
         for (const key of allowedFields) {

--- a/src/clients/AuthentikClient/models.ts
+++ b/src/clients/AuthentikClient/models.ts
@@ -40,6 +40,8 @@ export interface TeamAttributeDefinition {
     teamType: TeamType,
     seasonType: SeasonType | ServiceSeasonType,
     seasonYear: number,
+    teamStartDate?: string,
+    teamEndDate?: string,
     peoplePortalCreation?: boolean,
     flaggedForDeletion?: boolean,
     description: string,
@@ -167,7 +169,10 @@ export interface CreateTeamRequest {
         teamType: TeamType,
         seasonType: SeasonType | ServiceSeasonType,
         seasonYear: number,
-        description: string
+        description: string,
+        /* Optional: only top-level teams carry meeting dates; sub-teams omit them */
+        teamStartDate?: string,
+        teamEndDate?: string,
     }
 }
 

--- a/src/clients/PeoplePortalClient/index.ts
+++ b/src/clients/PeoplePortalClient/index.ts
@@ -57,6 +57,11 @@ export class PeoplePortalClient implements SharedResourceClient {
             friendlyName: "Allow Member Management",
             description: "Enabling this allows people in this subteam to add & remove members to your team",
         },
+
+        "corp:meetingsmgmt": {
+            friendlyName: "Allow Meeting Management",
+            description: "Enabling this allows members in this subteam to create, modify and delete team meetings",
+        },
     }
 
     async init(): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,7 @@ export const ENABLED_SHARED_RESOURCES: { [key: string]: SharedResourceClient } =
 
 /* Define Enabled Root Team Setting Resources Here */
 export const ENABLED_TEAMSETTING_RESOURCES: { [key: string]: RootTeamSettingClient } = {
-  awsClient: new AWSClient()
+  // awsClient: new AWSClient()
 }
 
 /* Define Enabled Service Teams Here */

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -111,7 +111,13 @@ export class AuthController extends Controller {
         }
 
         if (return_to) {
-            req.session.tempsession.return_to = return_to;
+            /* Only same-host or relative targets: return_to is redirected to
+               verbatim after login, so anything else is an open redirect. */
+            let safe = return_to.startsWith("/") && !return_to.startsWith("//");
+            if (!safe) {
+                try { safe = new URL(return_to).host === req.get("host"); } catch { safe = false; }
+            }
+            if (safe) req.session.tempsession.return_to = return_to;
         }
 
         let authFlowResponse = OpenIdClient.startAuthFlow()

--- a/src/controllers/MeetingsController.ts
+++ b/src/controllers/MeetingsController.ts
@@ -1,0 +1,179 @@
+/**
+  People Portal Server
+  Copyright (C) 2026  Atheesh Thirumalairajan
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import * as express from "express";
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Patch,
+    Path,
+    Post,
+    Request,
+    Route,
+    Security,
+    SuccessResponse,
+    Tags,
+} from "tsoa";
+import { TeamMeeting } from "../models/TeamMeeting";
+import { CustomValidationError } from "../utils/errors";
+
+
+interface APITeamMeetingCreateRequest {
+    name: string;
+    description?: string;
+    day: number;
+    start: number;
+    end: number;
+}
+
+interface APITeamMeetingUpdateRequest {
+    name?: string;
+    description?: string;
+    day?: number;
+    start?: number;
+    end?: number;
+}
+
+export interface APITeamMeetingResponse {
+    _id: string;
+    teamPk: string;
+    name: string;
+    description: string;
+    day: number;
+    start: number;
+    end: number;
+    createdBy: number;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+
+@Route("/api/org/teams")
+export class MeetingsController extends Controller {
+    /**
+     * Returns all meetings scheduled for a team, ordered by day then start time.
+     *
+     * @param teamId Authentik group PK of the team
+     */
+    @Get("{teamId}/meetings")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async getTeamMeetings(
+        @Path() teamId: string,
+    ): Promise<APITeamMeetingResponse[]> {
+        return await TeamMeeting
+            .find({ teamPk: teamId })
+            .sort({ day: 1, start: 1 })
+            .lean()
+            .exec() as any as APITeamMeetingResponse[];
+    }
+
+    /**
+     * Creates a new meeting for the given team.
+     * Requires the requesting user to be a Team Lead (or superuser) for the team.
+     *
+     * @param teamId Authentik group PK of the team
+     * @param body   Meeting details
+     */
+    @Post("{teamId}/meetings")
+    @Tags("Team Meetings")
+    @SuccessResponse(201)
+    @Security("oidc")
+    async createTeamMeeting(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+        @Body() body: APITeamMeetingCreateRequest,
+    ): Promise<APITeamMeetingResponse> {
+        if (body.start >= body.end) {
+            throw new CustomValidationError(400, "Meeting start time must be before end time");
+        }
+
+        const meeting = await TeamMeeting.create({
+            teamPk:      teamId,
+            name:        body.name,
+            description: body.description ?? "",
+            day:         body.day,
+            start:       body.start,
+            end:         body.end,
+            createdBy:   req.session.authorizedUser!.pk,
+        });
+
+        this.setStatus(201);
+        return meeting.toObject() as APITeamMeetingResponse;
+    }
+
+    /**
+     * Updates an existing team meeting. Only the fields provided in the
+     * request body are changed.
+     * Requires the requesting user to be a Team Lead (or superuser) for the team.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting
+     * @param body      Fields to update
+     */
+    @Patch("{teamId}/meetings/{meetingId}")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async updateTeamMeeting(
+        @Path() teamId: string,
+        @Path() meetingId: string,
+        @Body() body: APITeamMeetingUpdateRequest,
+    ): Promise<APITeamMeetingResponse> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId });
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+
+        if (body.name        !== undefined) meeting.name        = body.name;
+        if (body.description !== undefined) meeting.description = body.description;
+        if (body.day         !== undefined) meeting.day         = body.day;
+        if (body.start       !== undefined) meeting.start       = body.start;
+        if (body.end         !== undefined) meeting.end         = body.end;
+
+        const effectiveStart = body.start ?? meeting.start;
+        const effectiveEnd   = body.end   ?? meeting.end;
+        if (effectiveStart >= effectiveEnd) {
+            throw new CustomValidationError(400, "Meeting start time must be before end time");
+        }
+
+        await meeting.save();
+        return meeting.toObject() as APITeamMeetingResponse;
+    }
+
+    /**
+     * Permanently deletes a team meeting.
+     * Requires the requesting user to be a Team Lead (or superuser) for the team.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting
+     */
+    @Delete("{teamId}/meetings/{meetingId}")
+    @Tags("Team Meetings")
+    @SuccessResponse(204)
+    @Security("oidc")
+    async deleteTeamMeeting(
+        @Path() teamId: string,
+        @Path() meetingId: string,
+    ): Promise<void> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId });
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+        await meeting.deleteOne();
+    }
+}

--- a/src/controllers/MeetingsController.ts
+++ b/src/controllers/MeetingsController.ts
@@ -34,7 +34,11 @@ import {
     Tags,
 } from "tsoa";
 import { TeamMeeting } from "../models/TeamMeeting";
+import { MeetingAttendance, AttendanceRole } from "../models/MeetingAttendance";
+import { MeetingSubteamAttendance } from "../models/MeetingSubteamAttendance";
 import { AuthentikClient } from "../clients/AuthentikClient";
+import { BindleController } from "./BindleController";
+import { executiveAuthVerify } from "../auth";
 import { CustomValidationError } from "../utils/errors";
 
 /** Which occurrences of a recurring series a mutation applies to */
@@ -47,6 +51,79 @@ interface APITeamMeetingCreateRequest {
     end: Date;
     /** When true, the meeting repeats weekly through the team's end date */
     recurring?: boolean;
+    /** Authentik user PKs expected to attend */
+    requiredAttendees?: number[];
+    /** Authentik user PKs invited but not required */
+    optionalAttendees?: number[];
+    /** Authentik group PKs of subteams expected to attend (stored by reference) */
+    requiredSubteams?: string[];
+    /** Authentik group PKs of subteams invited but not required */
+    optionalSubteams?: string[];
+    /** When true the meeting is visible to everyone, invited or not */
+    visibleToAll?: boolean;
+}
+
+/** A selectable team member for the attendee picker */
+export interface APIMeetingRosterMember {
+    pk: number;
+    name: string;
+    username: string;
+    email: string;
+}
+
+export interface APIMeetingAttendee {
+    userPk: number;
+    name: string;
+    role: AttendanceRole;
+    present: boolean;
+    markedBy: number | null;
+    markedAt: Date | null;
+    /**
+     * True when the person has their own MeetingAttendance row (individually
+     * added or already checked in). False for people included only because
+     * their subteam is invited — those rows are materialized on first mark.
+     */
+    explicit: boolean;
+    /** Display name of the invited subteam this person attends through, if any */
+    viaSubteam: string | null;
+}
+
+/** A subteam invited to a meeting, by reference */
+export interface APIMeetingSubteamRef {
+    subteamPk: string;
+    name: string;
+    role: AttendanceRole;
+}
+
+export interface APIMeetingAttendanceResponse {
+    /** Authentik user PK of the requester (so the UI can find "me") */
+    viewerPk: number;
+    /** True when the requester may mark anyone present */
+    canManage: boolean;
+    attendees: APIMeetingAttendee[];
+    /** Subteams invited by reference; their members appear in `attendees` */
+    subteams: APIMeetingSubteamRef[];
+}
+
+/** A meeting the requester is an attendee of, plus their own attendance. */
+export interface APIMyAttendanceItem extends APITeamMeetingResponse {
+    role: AttendanceRole;
+    present: boolean;
+}
+
+interface APIMarkAttendanceRequest {
+    present: boolean;
+}
+
+interface APIAddAttendeeRequest {
+    userPk: number;
+    role?: AttendanceRole;
+}
+
+interface APIAddSubteamRequest {
+    /** Authentik group PK of the subteam to invite */
+    subteamPk: string;
+    role?: AttendanceRole;
 }
 
 interface APITeamMeetingUpdateRequest {
@@ -54,6 +131,8 @@ interface APITeamMeetingUpdateRequest {
     description?: string;
     start?: Date;
     end?: Date;
+    /** When provided, toggles whether uninvited members can see the meeting */
+    visibleToAll?: boolean;
     /** Defaults to "this" when omitted */
     scope?: MeetingScope;
 }
@@ -68,6 +147,8 @@ export interface APITeamMeetingResponse {
     start: Date;
     end: Date;
     createdBy: number;
+    /** Whether uninvited team members can see this meeting on the calendar */
+    visibleToAll: boolean;
     createdAt: Date;
     updatedAt: Date;
 }
@@ -98,9 +179,146 @@ export class MeetingsController extends Controller {
     private readonly authentikClient = new AuthentikClient();
 
     /**
+     * Per-request memo of Authentik group lookups (tsoa constructs a fresh
+     * controller per request). Roster, subteam directory, and the manager check
+     * all need the same group tree; without this each would re-fan-out 1+N
+     * sequential Authentik calls.
+     */
+    private readonly groupInfoCache = new Map<string, ReturnType<AuthentikClient["getGroupInfo"]>>();
+
+    private getGroupInfoCached(groupPk: string) {
+        let pending = this.groupInfoCache.get(groupPk);
+        if (!pending) {
+            pending = this.authentikClient.getGroupInfo(groupPk);
+            this.groupInfoCache.set(groupPk, pending);
+        }
+        return pending;
+    }
+
+    /**
+     * Flattens a team into its full member roster: the team's own users (owners)
+     * plus everyone in its subteams, de-duplicated by Authentik user PK.
+     */
+    private async getTeamRoster(teamId: string): Promise<Map<number, APIMeetingRosterMember>> {
+        const teamInfo = await this.getGroupInfoCached(teamId);
+        const members = new Map<number, APIMeetingRosterMember>();
+        /* Authentik user PKs arrive as strings here but are numeric everywhere
+           attendance is stored (matching authorizedUser.pk); normalize to number. */
+        const add = (u: { pk: string | number; name: string; username: string; email: string } | undefined) => {
+            if (!u) return;
+            const pk = Number(u.pk);
+            if (!members.has(pk)) {
+                members.set(pk, { pk, name: u.name, username: u.username, email: u.email });
+            }
+        };
+        teamInfo.users.forEach(add);
+        teamInfo.subteams?.forEach((subteam: any) => (subteam.users ?? []).forEach(add));
+        return members;
+    }
+
+    /**
+     * The team's subteams keyed by group PK, each with its current member PKs.
+     * Subteam invites store only this PK, so membership resolved here always
+     * reflects the subteam's present composition.
+     */
+    private async getSubteamDirectory(teamId: string): Promise<Map<string, { pk: string; name: string; memberPks: Set<number> }>> {
+        const teamInfo = await this.getGroupInfoCached(teamId);
+        const directory = new Map<string, { pk: string; name: string; memberPks: Set<number> }>();
+        for (const subteam of (teamInfo.subteams ?? []) as any[]) {
+            if (subteam.attributes?.flaggedForDeletion) continue;
+            directory.set(String(subteam.pk), {
+                pk:        String(subteam.pk),
+                name:      subteam.attributes?.friendlyName ?? subteam.name,
+                memberPks: new Set((subteam.users ?? []).map((u: any) => Number(u.pk))),
+            });
+        }
+        return directory;
+    }
+
+    /**
+     * The visibility predicate for a single meeting, mirroring the list filter:
+     * visible-to-all, uninvited (general audience), directly invited, member of
+     * an invited subteam, or a meeting manager. Ordered cheapest-first.
+     */
+    private async canViewMeeting(
+        req: express.Request,
+        teamId: string,
+        meeting: { _id: unknown; visibleToAll?: boolean },
+    ): Promise<boolean> {
+        if (meeting.visibleToAll) return true;
+
+        const meetingId = String(meeting._id);
+        const viewerPk = req.session.authorizedUser!.pk;
+        const [inviteCount, ownRow, subteamInvites] = await Promise.all([
+            MeetingAttendance.countDocuments({ meetingId }),
+            MeetingAttendance.findOne({ meetingId, userPk: viewerPk }).select("_id").lean(),
+            MeetingSubteamAttendance.find({ meetingId }).select("subteamPk").lean(),
+        ]);
+        if (ownRow) return true;
+        if (inviteCount === 0 && subteamInvites.length === 0) return true;
+        if (subteamInvites.length > 0) {
+            const directory = await this.getSubteamDirectory(teamId);
+            if (subteamInvites.some((invite) => directory.get(invite.subteamPk)?.memberPks.has(viewerPk))) {
+                return true;
+            }
+        }
+        return this.canManageMeetings(req, teamId);
+    }
+
+    /**
+     * Resolves the role a person holds on a meeting through subteam invites:
+     * "required" if any invited subteam they belong to is required, "optional"
+     * if only optional ones cover them, null when no invite covers them.
+     */
+    private resolveSubteamRole(
+        invites: Array<{ subteamPk: string; role: AttendanceRole }>,
+        directory: Map<string, { memberPks: Set<number> }>,
+        userPk: number,
+    ): AttendanceRole | null {
+        const covering = invites.filter((invite) => directory.get(invite.subteamPk)?.memberPks.has(userPk));
+        if (covering.length === 0) return null;
+        return covering.some((invite) => invite.role === "required") ? "required" : "optional";
+    }
+
+    /**
+     * Whether the requesting user may manage attendance for everyone on the team
+     * (Team Owner, holder of the `corp:meetingsmgmt` bindle, or a superuser).
+     * Used by endpoints that allow either a manager or the attendee themselves.
+     */
+    private async canManageMeetings(req: express.Request, teamId: string): Promise<boolean> {
+        const user = req.session.authorizedUser!;
+        if (user.is_superuser) return true;
+
+        /* Executive Board members manage every team, mirroring the override the
+           bindle auth layer applies to create/edit/delete. OIDC is already
+           verified by @Security("oidc"), so skip the redundant check. */
+        try {
+            if (await executiveAuthVerify(req, [], true)) return true;
+        } catch { /* not an executive — fall through to owner/bindle checks */ }
+
+        const teamInfo = await this.getGroupInfoCached(teamId);
+
+        /* Owner check mirrors the bindle auth layer: ownership lives on the root team. */
+        let authoritativeTeam = teamInfo;
+        if (teamInfo.parentPk) {
+            authoritativeTeam = await this.getGroupInfoCached(teamInfo.parentPk);
+        }
+        if (authoritativeTeam.attributes.peoplePortalCreation && new Set(user.groups).has(authoritativeTeam.name)) {
+            return true;
+        }
+
+        const effective = BindleController.getEffectivePermissionSet(teamInfo, user.groups);
+        return effective.has("corp:meetingsmgmt");
+    }
+
+    /**
      * Returns meetings scheduled for a team, ordered by start time. When `from`
      * and/or `to` are supplied, only occurrences starting within that range are
      * returned (used to load a single visible week).
+     *
+     * Meeting managers see everything. Everyone else sees a meeting only when
+     * it is marked visible to all, has no invite list at all (assumed general
+     * audience), or they are invited — directly or through one of their subteams.
      *
      * @param teamId Authentik group PK of the team
      * @param from   ISO datetime; include occurrences starting at or after this
@@ -111,6 +329,7 @@ export class MeetingsController extends Controller {
     @SuccessResponse(200)
     @Security("oidc")
     async getTeamMeetings(
+        @Request() req: express.Request,
         @Path() teamId: string,
         @Query() from?: Date,
         @Query() to?: Date,
@@ -123,11 +342,42 @@ export class MeetingsController extends Controller {
             filter.start = range;
         }
 
-        const meetings = await TeamMeeting
+        let meetings = await TeamMeeting
             .find(filter)
             .sort({ start: 1 })
             .lean()
             .exec();
+
+        if (meetings.length > 0 && !(await this.canManageMeetings(req, teamId))) {
+            const viewerPk = req.session.authorizedUser!.pk;
+            const ids = meetings.map((m) => String(m._id));
+            const [invitedIds, viewerRows, subteamInvites] = await Promise.all([
+                MeetingAttendance.distinct("meetingId", { meetingId: { $in: ids } }),
+                MeetingAttendance.find({ meetingId: { $in: ids }, userPk: viewerPk }).select("meetingId").lean(),
+                MeetingSubteamAttendance.find({ meetingId: { $in: ids } }).select("meetingId subteamPk").lean(),
+            ]);
+
+            /* A meeting with any invite (person or subteam) is targeted, not general. */
+            const hasInvites = new Set<string>(invitedIds as string[]);
+            subteamInvites.forEach((invite) => hasInvites.add(invite.meetingId));
+
+            const invitedDirectly = new Set(viewerRows.map((row) => row.meetingId));
+            const directory = await this.getSubteamDirectory(teamId);
+            const mySubteams = new Set(
+                [...directory.values()].filter((s) => s.memberPks.has(viewerPk)).map((s) => s.pk),
+            );
+            const invitedViaSubteam = new Set(
+                subteamInvites.filter((invite) => mySubteams.has(invite.subteamPk)).map((invite) => invite.meetingId),
+            );
+
+            meetings = meetings.filter((m) => {
+                const id = String(m._id);
+                return m.visibleToAll
+                    || !hasInvites.has(id)
+                    || invitedDirectly.has(id)
+                    || invitedViaSubteam.has(id);
+            });
+        }
 
         /* `recurring` is derived, never stored: a series is recurring when more
            than one occurrence shares its seriesId. The visible week may hold only
@@ -171,7 +421,7 @@ export class MeetingsController extends Controller {
         let occurrences: Array<{ start: Date; end: Date }>;
         if (body.recurring) {
             /* Recurring meetings repeat weekly through the team's end date */
-            const teamInfo = await this.authentikClient.getGroupInfo(teamId);
+            const teamInfo = await this.getGroupInfoCached(teamId);
             const teamEndDate = teamInfo.attributes.teamEndDate;
             if (!teamEndDate) {
                 throw new CustomValidationError(400, "Team has no end date set; cannot create a recurring meeting");
@@ -187,16 +437,66 @@ export class MeetingsController extends Controller {
 
         const seriesId = randomUUID();
         const docs = occurrences.map((occurrence) => ({
-            teamPk:      teamId,
+            teamPk:       teamId,
             seriesId,
-            name:        body.name,
-            description: body.description ?? "",
-            start:       occurrence.start,
-            end:         occurrence.end,
-            createdBy:   req.session.authorizedUser!.pk,
+            name:         body.name,
+            description:  body.description ?? "",
+            start:        occurrence.start,
+            end:          occurrence.end,
+            createdBy:    req.session.authorizedUser!.pk,
+            visibleToAll: body.visibleToAll ?? false,
         }));
 
         const created = await TeamMeeting.insertMany(docs);
+
+        /* Attendees are stored per occurrence: each created meeting gets its own
+           copy of the required/optional roster. A person listed as both required
+           and optional is kept as required. */
+        const required = new Set(body.requiredAttendees ?? []);
+        const optional = new Set((body.optionalAttendees ?? []).filter((pk) => !required.has(pk)));
+        const roster: Array<{ userPk: number; role: AttendanceRole }> = [
+            ...[...required].map((userPk) => ({ userPk, role: "required" as const })),
+            ...[...optional].map((userPk) => ({ userPk, role: "optional" as const })),
+        ];
+
+        if (roster.length > 0) {
+            const attendanceDocs = created.flatMap((meeting) =>
+                roster.map((entry) => ({
+                    meetingId: String(meeting._id),
+                    teamPk:    teamId,
+                    seriesId,
+                    userPk:    entry.userPk,
+                    role:      entry.role,
+                    present:   false,
+                })),
+            );
+            await MeetingAttendance.insertMany(attendanceDocs);
+        }
+
+        /* Subteam invites are stored by group PK only — membership is resolved
+           at read time so the invite follows the subteam as it grows/shrinks.
+           Unknown PKs are dropped; a subteam listed as both is kept required. */
+        if ((body.requiredSubteams?.length ?? 0) > 0 || (body.optionalSubteams?.length ?? 0) > 0) {
+            const directory = await this.getSubteamDirectory(teamId);
+            const requiredSubs = new Set((body.requiredSubteams ?? []).filter((pk) => directory.has(pk)));
+            const optionalSubs = new Set((body.optionalSubteams ?? []).filter((pk) => directory.has(pk) && !requiredSubs.has(pk)));
+            const subteamRoster: Array<{ subteamPk: string; role: AttendanceRole }> = [
+                ...[...requiredSubs].map((subteamPk) => ({ subteamPk, role: "required" as const })),
+                ...[...optionalSubs].map((subteamPk) => ({ subteamPk, role: "optional" as const })),
+            ];
+            if (subteamRoster.length > 0) {
+                const subteamDocs = created.flatMap((meeting) =>
+                    subteamRoster.map((entry) => ({
+                        meetingId: String(meeting._id),
+                        teamPk:    teamId,
+                        seriesId,
+                        subteamPk: entry.subteamPk,
+                        role:      entry.role,
+                    })),
+                );
+                await MeetingSubteamAttendance.insertMany(subteamDocs);
+            }
+        }
 
         /* Derived for the response only — every doc just created shares one series. */
         const recurring = created.length > 1;
@@ -259,8 +559,9 @@ export class MeetingsController extends Controller {
 
         const occurrences = await TeamMeeting.find(filter);
         for (const occurrence of occurrences) {
-            if (body.name        !== undefined) occurrence.name        = body.name;
-            if (body.description !== undefined) occurrence.description = body.description;
+            if (body.name         !== undefined) occurrence.name         = body.name;
+            if (body.description  !== undefined) occurrence.description  = body.description;
+            if (body.visibleToAll !== undefined) occurrence.visibleToAll = body.visibleToAll;
             if (timeChanged) {
                 occurrence.start = new Date(occurrence.start.getTime() + startDelta);
                 occurrence.end   = new Date(occurrence.start.getTime() + duration);
@@ -302,6 +603,502 @@ export class MeetingsController extends Controller {
             filter.start = { $gte: target.start };
         }
 
+        /* Drop attendance for exactly the occurrences being removed. */
+        const doomed = await TeamMeeting.find(filter).select("_id").lean();
+        const doomedIds = doomed.map((m) => m._id.toString());
         await TeamMeeting.deleteMany(filter);
+        if (doomedIds.length > 0) {
+            await MeetingAttendance.deleteMany({ meetingId: { $in: doomedIds } });
+            await MeetingSubteamAttendance.deleteMany({ meetingId: { $in: doomedIds } });
+        }
+    }
+
+    /**
+     * Returns the team's full member roster for the attendee picker.
+     *
+     * @param teamId Authentik group PK of the team
+     */
+    @Get("{teamId}/meetings/roster")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async getMeetingRoster(@Path() teamId: string): Promise<APIMeetingRosterMember[]> {
+        const roster = await this.getTeamRoster(teamId);
+        return [...roster.values()].sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    /**
+     * Reports whether the requesting user may manage this team's meetings
+     * (create/edit/delete meetings and manage anyone's attendance). Lets the UI
+     * hide management controls for users who lack the `corp:meetingsmgmt` bindle.
+     *
+     * @param teamId Authentik group PK of the team
+     */
+    @Get("{teamId}/meetings/capabilities")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async getMeetingCapabilities(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+    ): Promise<{ canManageMeetings: boolean }> {
+        return { canManageMeetings: await this.canManageMeetings(req, teamId) };
+    }
+
+    /**
+     * Returns the meetings the requesting user is an attendee of, with their own
+     * attendance status — their personal list of attendances. Optionally bounded
+     * to a date range by occurrence start time.
+     *
+     * @param teamId Authentik group PK of the team
+     * @param from   ISO datetime; include occurrences starting at or after this
+     * @param to     ISO datetime; include occurrences starting before this
+     */
+    @Get("{teamId}/meetings/mine")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async getMyAttendance(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+        @Query() from?: Date,
+        @Query() to?: Date,
+    ): Promise<APIMyAttendanceItem[]> {
+        const viewerPk = req.session.authorizedUser!.pk;
+        const records = await MeetingAttendance.find({ teamPk: teamId, userPk: viewerPk }).lean();
+        const byMeeting = new Map(records.map((r) => [r.meetingId, r] as const));
+
+        /* Meetings the viewer attends through a subteam invite, without an own
+           row yet: resolved live against current subteam membership. */
+        const directory = await this.getSubteamDirectory(teamId);
+        const mySubteamPks = [...directory.values()].filter((s) => s.memberPks.has(viewerPk)).map((s) => s.pk);
+        const subteamRole = new Map<string, AttendanceRole>();
+        if (mySubteamPks.length > 0) {
+            const invites = await MeetingSubteamAttendance
+                .find({ teamPk: teamId, subteamPk: { $in: mySubteamPks } })
+                .lean();
+            for (const invite of invites) {
+                const current = subteamRole.get(invite.meetingId);
+                if (current !== "required") subteamRole.set(invite.meetingId, invite.role);
+            }
+        }
+
+        const meetingIds = [...new Set([...byMeeting.keys(), ...subteamRole.keys()])];
+        if (meetingIds.length === 0) return [];
+
+        const filter: Record<string, unknown> = { _id: { $in: meetingIds }, teamPk: teamId };
+        if (from || to) {
+            const range: Record<string, Date> = {};
+            if (from) range.$gte = from;
+            if (to) range.$lt = to;
+            filter.start = range;
+        }
+
+        const meetings = await TeamMeeting.find(filter).sort({ start: 1 }).lean();
+        const seriesIds = [...new Set(meetings.map((m) => m.seriesId))];
+        const counts = await TeamMeeting.aggregate<{ _id: string; count: number }>([
+            { $match: { seriesId: { $in: seriesIds } } },
+            { $group: { _id: "$seriesId", count: { $sum: 1 } } },
+        ]);
+        const seriesSize = new Map(counts.map((c) => [c._id, c.count]));
+
+        return meetings.map((m) => {
+            const record = byMeeting.get(String(m._id));
+            return {
+                ...m,
+                recurring: (seriesSize.get(m.seriesId) ?? 1) > 1,
+                role: record?.role ?? subteamRole.get(String(m._id)) ?? "optional",
+                present: record?.present ?? false,
+            };
+        }) as any as APIMyAttendanceItem[];
+    }
+
+    /**
+     * Returns a single meeting occurrence by id. Available to any authenticated
+     * user so the check-in and detail pages can show what they are checking in to.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     */
+    @Get("{teamId}/meetings/{meetingId}")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async getTeamMeeting(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+        @Path() meetingId: string,
+    ): Promise<APITeamMeetingResponse> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId }).lean();
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+        /* Same predicate as the calendar list; 404 (not 403) so an uninvited
+           member can't even confirm a hidden meeting exists. */
+        if (!(await this.canViewMeeting(req, teamId, meeting))) {
+            throw new CustomValidationError(404, "Meeting not found");
+        }
+        const recurring = await TeamMeeting.countDocuments({ seriesId: meeting.seriesId }) > 1;
+        return { ...meeting, recurring } as any as APITeamMeetingResponse;
+    }
+
+    /**
+     * Self check-in for the requesting user, intended for the QR-code flow: the
+     * signed-in person who scans the meeting's code marks themselves present.
+     * A team member not yet on the sheet is added (as optional) and marked
+     * present. Only ever affects the caller's own row, and only within the
+     * meeting's check-in window.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     */
+    @Post("{teamId}/meetings/{meetingId}/checkin")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("oidc")
+    async checkInToMeeting(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+        @Path() meetingId: string,
+    ): Promise<APIMeetingAttendee> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId }).lean();
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+
+        /* Check-in is open for the whole calendar day of the meeting, so a code
+           can't be scanned on a different day but timing within the day is lenient. */
+        const now = Date.now();
+        const opensAt = new Date(meeting.start); opensAt.setHours(0, 0, 0, 0);
+        const closesAt = new Date(meeting.end); closesAt.setHours(23, 59, 59, 999);
+        if (now < opensAt.getTime()) throw new CustomValidationError(400, "Check-in for this meeting is not open yet");
+        if (now > closesAt.getTime()) throw new CustomValidationError(400, "Check-in for this meeting has closed");
+
+        const viewerPk = req.session.authorizedUser!.pk;
+        const roster = await this.getTeamRoster(teamId);
+
+        /* Outsiders may not self-add. Pre-listed attendees are always allowed. */
+        const existing = await MeetingAttendance.findOne({ meetingId, teamPk: teamId, userPk: viewerPk });
+        if (!existing && !roster.has(viewerPk)) {
+            throw new CustomValidationError(403, "You are not a member of this team");
+        }
+
+        /* First check-in of a subteam invitee materializes their row with the
+           subteam's role; anyone else lands as "optional". */
+        let insertRole: AttendanceRole = "optional";
+        if (!existing) {
+            const invites = await MeetingSubteamAttendance.find({ meetingId, teamPk: teamId }).lean();
+            if (invites.length > 0) {
+                const directory = await this.getSubteamDirectory(teamId);
+                insertRole = this.resolveSubteamRole(invites, directory, viewerPk) ?? "optional";
+            }
+        }
+
+        /* Atomic upsert so a fast re-scan/refresh can't trip the unique
+           (meetingId, userPk) index with a duplicate-key error. `role` is only
+           set on insert, preserving a manager-assigned "required" role. */
+        const record = await MeetingAttendance.findOneAndUpdate(
+            { meetingId, teamPk: teamId, userPk: viewerPk },
+            {
+                $setOnInsert: { seriesId: meeting.seriesId, role: insertRole },
+                $set: { present: true, markedBy: viewerPk, markedAt: new Date() },
+            },
+            { new: true, upsert: true, setDefaultsOnInsert: true },
+        );
+        if (!record) throw new CustomValidationError(500, "Failed to record attendance");
+
+        return {
+            userPk:     record.userPk,
+            name:       roster.get(record.userPk)?.name ?? `User ${record.userPk}`,
+            role:       record.role,
+            present:    record.present,
+            markedBy:   record.markedBy ?? null,
+            markedAt:   record.markedAt ?? null,
+            explicit:   true,
+            viaSubteam: null,
+        };
+    }
+
+    /**
+     * Returns the attendance sheet for a single meeting occurrence: every invited
+     * attendee with their role and present flag. Restricted to meeting
+     * managers (Team Owner, executive, or the `corp:meetingsmgmt` bindle) — the
+     * sheet is not visible to ordinary attendees.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     */
+    @Get("{teamId}/meetings/{meetingId}/attendance")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("bindles", ["corp:meetingsmgmt"])
+    async getMeetingAttendance(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+        @Path() meetingId: string,
+    ): Promise<APIMeetingAttendanceResponse> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId }).lean();
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+
+        const [records, invites] = await Promise.all([
+            MeetingAttendance.find({ meetingId, teamPk: teamId }).lean(),
+            MeetingSubteamAttendance.find({ meetingId, teamPk: teamId }).lean(),
+        ]);
+        const roster = await this.getTeamRoster(teamId);
+        const directory = await this.getSubteamDirectory(teamId);
+
+        /* Attribute each covered person to one invited subteam for display;
+           required invites win so the label matches the effective role. */
+        const viaSubteam = new Map<number, string>();
+        const sortedInvites = [...invites].sort((a, b) => (a.role === b.role ? 0 : a.role === "required" ? -1 : 1));
+        for (const invite of sortedInvites) {
+            const subteam = directory.get(invite.subteamPk);
+            if (!subteam) continue;
+            subteam.memberPks.forEach((pk) => { if (!viaSubteam.has(pk)) viaSubteam.set(pk, subteam.name); });
+        }
+
+        const attendees: APIMeetingAttendee[] = records.map((r) => ({
+            userPk:     r.userPk,
+            name:       roster.get(r.userPk)?.name ?? `User ${r.userPk}`,
+            role:       r.role,
+            present:    r.present,
+            markedBy:   r.markedBy ?? null,
+            markedAt:   r.markedAt ?? null,
+            explicit:   true,
+            viaSubteam: viaSubteam.get(r.userPk) ?? null,
+        }));
+
+        /* Members covered by a subteam invite but without their own row yet:
+           resolved fresh from the subteam's current membership. */
+        const explicitPks = new Set(records.map((r) => r.userPk));
+        for (const [pk, subteamName] of viaSubteam) {
+            if (explicitPks.has(pk)) continue;
+            attendees.push({
+                userPk:     pk,
+                name:       roster.get(pk)?.name ?? `User ${pk}`,
+                role:       this.resolveSubteamRole(invites, directory, pk)!,
+                present:    false,
+                markedBy:   null,
+                markedAt:   null,
+                explicit:   false,
+                viaSubteam: subteamName,
+            });
+        }
+
+        attendees.sort((a, b) => (a.role === b.role ? a.name.localeCompare(b.name) : a.role === "required" ? -1 : 1));
+
+        /* Reaching here means the bindle gate passed, so the viewer always manages. */
+        return {
+            viewerPk:  req.session.authorizedUser!.pk,
+            canManage: true,
+            attendees,
+            subteams:  invites.map((invite) => ({
+                subteamPk: invite.subteamPk,
+                name:      directory.get(invite.subteamPk)?.name ?? invite.subteamPk,
+                role:      invite.role,
+            })),
+        };
+    }
+
+    /**
+     * Adds a person to a meeting occurrence's attendance sheet.
+     * Requires Team Owner or the `corp:meetingsmgmt` bindle.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     * @param body      The attendee to add and their role (defaults to required)
+     */
+    @Post("{teamId}/meetings/{meetingId}/attendance")
+    @Tags("Team Meetings")
+    @SuccessResponse(201)
+    @Security("bindles", ["corp:meetingsmgmt"])
+    async addMeetingAttendee(
+        @Path() teamId: string,
+        @Path() meetingId: string,
+        @Body() body: APIAddAttendeeRequest,
+    ): Promise<APIMeetingAttendee> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId }).lean();
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+
+        const role: AttendanceRole = body.role === "optional" ? "optional" : "required";
+        try {
+            await MeetingAttendance.create({
+                meetingId,
+                teamPk:   teamId,
+                seriesId: meeting.seriesId,
+                userPk:   body.userPk,
+                role,
+                present:  false,
+            });
+        } catch (e: any) {
+            /* The unique (meetingId, userPk) index is the real duplicate guard —
+               a pre-check would race with concurrent adds/check-ins. */
+            if (e?.code === 11000) throw new CustomValidationError(409, "Person is already an attendee");
+            throw e;
+        }
+
+        const roster = await this.getTeamRoster(teamId);
+        this.setStatus(201);
+        return {
+            userPk:     body.userPk,
+            name:       roster.get(body.userPk)?.name ?? `User ${body.userPk}`,
+            role,
+            present:    false,
+            markedBy:   null,
+            markedAt:   null,
+            explicit:   true,
+            viaSubteam: null,
+        };
+    }
+
+    /**
+     * Invites an entire subteam to a meeting occurrence, by reference: whoever
+     * is in the subteam when attendance is read or marked counts as invited,
+     * so the invite tracks the subteam as it grows or shrinks.
+     * Requires Team Owner or the `corp:meetingsmgmt` bindle.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     * @param body      The subteam to invite and its role (defaults to required)
+     */
+    @Post("{teamId}/meetings/{meetingId}/attendance/subteams")
+    @Tags("Team Meetings")
+    @SuccessResponse(201)
+    @Security("bindles", ["corp:meetingsmgmt"])
+    async addMeetingSubteam(
+        @Path() teamId: string,
+        @Path() meetingId: string,
+        @Body() body: APIAddSubteamRequest,
+    ): Promise<APIMeetingSubteamRef> {
+        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId }).lean();
+        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+
+        const directory = await this.getSubteamDirectory(teamId);
+        const subteam = directory.get(body.subteamPk);
+        if (!subteam) throw new CustomValidationError(400, "Not a subteam of this team");
+
+        const role: AttendanceRole = body.role === "optional" ? "optional" : "required";
+        try {
+            await MeetingSubteamAttendance.create({
+                meetingId,
+                teamPk:    teamId,
+                seriesId:  meeting.seriesId,
+                subteamPk: body.subteamPk,
+                role,
+            });
+        } catch (e: any) {
+            /* The unique (meetingId, subteamPk) index is the real duplicate guard. */
+            if (e?.code === 11000) throw new CustomValidationError(409, "Subteam is already invited");
+            throw e;
+        }
+
+        this.setStatus(201);
+        return { subteamPk: body.subteamPk, name: subteam.name, role };
+    }
+
+    /**
+     * Removes a subteam invite from a meeting occurrence. Attendance rows
+     * already materialized for its members (e.g. by check-in) are kept.
+     * Requires Team Owner or the `corp:meetingsmgmt` bindle.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     * @param subteamPk Authentik group PK of the subteam to uninvite
+     */
+    @Delete("{teamId}/meetings/{meetingId}/attendance/subteams/{subteamPk}")
+    @Tags("Team Meetings")
+    @SuccessResponse(204)
+    @Security("bindles", ["corp:meetingsmgmt"])
+    async removeMeetingSubteam(
+        @Path() teamId: string,
+        @Path() meetingId: string,
+        @Path() subteamPk: string,
+    ): Promise<void> {
+        const result = await MeetingSubteamAttendance.deleteOne({ meetingId, teamPk: teamId, subteamPk });
+        if (result.deletedCount === 0) throw new CustomValidationError(404, "Subteam is not invited to this meeting");
+    }
+
+    /**
+     * Sets an attendee's present flag for a meeting occurrence.
+     * Restricted to meeting managers (Team Owner, executive, or the
+     * `corp:meetingsmgmt` bindle); attendees cannot mark their own attendance.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     * @param userPk    Authentik user PK of the attendee to mark
+     * @param body      The new present flag
+     */
+    @Patch("{teamId}/meetings/{meetingId}/attendance/{userPk}")
+    @Tags("Team Meetings")
+    @SuccessResponse(200)
+    @Security("bindles", ["corp:meetingsmgmt"])
+    async markAttendance(
+        @Request() req: express.Request,
+        @Path() teamId: string,
+        @Path() meetingId: string,
+        @Path() userPk: number,
+        @Body() body: APIMarkAttendanceRequest,
+    ): Promise<APIMeetingAttendee> {
+        if (typeof body.present !== "boolean") {
+            throw new CustomValidationError(400, "Invalid attendance value");
+        }
+
+        const viewerPk = req.session.authorizedUser!.pk;
+        const markUpdate = { present: body.present, markedBy: viewerPk, markedAt: new Date() };
+        let record = await MeetingAttendance.findOneAndUpdate(
+            { meetingId, teamPk: teamId, userPk },
+            { $set: markUpdate },
+            { new: true },
+        );
+        if (!record) {
+            /* Subteam invitees have no row until first marked — materialize one
+               with the role their subteam invite grants. Atomic upsert: the
+               person may check themselves in concurrently, and a plain save()
+               would trip the unique (meetingId, userPk) index. */
+            const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId }).lean();
+            if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+            const invites = await MeetingSubteamAttendance.find({ meetingId, teamPk: teamId }).lean();
+            const directory = invites.length > 0 ? await this.getSubteamDirectory(teamId) : new Map();
+            const role = this.resolveSubteamRole(invites, directory, userPk);
+            if (!role) throw new CustomValidationError(404, "This person is not an attendee of the meeting");
+            record = await MeetingAttendance.findOneAndUpdate(
+                { meetingId, teamPk: teamId, userPk },
+                {
+                    $setOnInsert: { seriesId: meeting.seriesId, role },
+                    $set: markUpdate,
+                },
+                { new: true, upsert: true, setDefaultsOnInsert: true },
+            );
+        }
+        if (!record) throw new CustomValidationError(500, "Failed to record attendance");
+
+        const roster = await this.getTeamRoster(teamId);
+        return {
+            userPk:     record.userPk,
+            name:       roster.get(record.userPk)?.name ?? `User ${record.userPk}`,
+            role:       record.role,
+            present:    record.present,
+            markedBy:   record.markedBy ?? null,
+            markedAt:   record.markedAt ?? null,
+            explicit:   true,
+            viaSubteam: null,
+        };
+    }
+
+    /**
+     * Removes a person from a meeting occurrence's attendance sheet.
+     * Requires Team Owner or the `corp:meetingsmgmt` bindle.
+     *
+     * @param teamId    Authentik group PK of the team
+     * @param meetingId MongoDB ObjectId of the meeting occurrence
+     * @param userPk    Authentik user PK of the attendee to remove
+     */
+    @Delete("{teamId}/meetings/{meetingId}/attendance/{userPk}")
+    @Tags("Team Meetings")
+    @SuccessResponse(204)
+    @Security("bindles", ["corp:meetingsmgmt"])
+    async removeMeetingAttendee(
+        @Path() teamId: string,
+        @Path() meetingId: string,
+        @Path() userPk: number,
+    ): Promise<void> {
+        const result = await MeetingAttendance.deleteOne({ meetingId, teamPk: teamId, userPk });
+        if (result.deletedCount === 0) throw new CustomValidationError(404, "Attendee not found");
     }
 }

--- a/src/controllers/MeetingsController.ts
+++ b/src/controllers/MeetingsController.ts
@@ -16,6 +16,7 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { randomUUID } from "crypto";
 import * as express from "express";
 import {
     Body,
@@ -25,6 +26,7 @@ import {
     Patch,
     Path,
     Post,
+    Query,
     Request,
     Route,
     Security,
@@ -32,45 +34,77 @@ import {
     Tags,
 } from "tsoa";
 import { TeamMeeting } from "../models/TeamMeeting";
+import { AuthentikClient } from "../clients/AuthentikClient";
 import { CustomValidationError } from "../utils/errors";
 
+/** Which occurrences of a recurring series a mutation applies to */
+type MeetingScope = "this" | "following" | "all";
 
 interface APITeamMeetingCreateRequest {
     name: string;
     description?: string;
-    day: number;
-    start: number;
-    end: number;
+    start: Date;
+    end: Date;
+    /** When true, the meeting repeats weekly through the team's end date */
+    recurring?: boolean;
 }
 
 interface APITeamMeetingUpdateRequest {
     name?: string;
     description?: string;
-    day?: number;
-    start?: number;
-    end?: number;
+    start?: Date;
+    end?: Date;
+    /** Defaults to "this" when omitted */
+    scope?: MeetingScope;
 }
 
 export interface APITeamMeetingResponse {
     _id: string;
     teamPk: string;
+    seriesId: string;
+    recurring: boolean;
     name: string;
     description: string;
-    day: number;
-    start: number;
-    end: number;
+    start: Date;
+    end: Date;
     createdBy: number;
     createdAt: Date;
     updatedAt: Date;
 }
 
+/** Generates weekly occurrence start/end pairs from `start`/`end` through `until` (inclusive). */
+function generateWeeklyOccurrences(start: Date, end: Date, until: Date): Array<{ start: Date; end: Date }> {
+    const occurrences: Array<{ start: Date; end: Date }> = [];
+    const cursorStart = new Date(start);
+    const cursorEnd = new Date(end);
+
+    /* Compare on date only so an occurrence on the `until` day is included */
+    const untilEnd = new Date(until);
+    untilEnd.setHours(23, 59, 59, 999);
+
+    while (cursorStart.getTime() <= untilEnd.getTime()) {
+        occurrences.push({ start: new Date(cursorStart), end: new Date(cursorEnd) });
+        /* setDate preserves wall-clock time across DST boundaries */
+        cursorStart.setDate(cursorStart.getDate() + 7);
+        cursorEnd.setDate(cursorEnd.getDate() + 7);
+    }
+
+    return occurrences;
+}
+
 
 @Route("/api/org/teams")
 export class MeetingsController extends Controller {
+    private readonly authentikClient = new AuthentikClient();
+
     /**
-     * Returns all meetings scheduled for a team, ordered by day then start time.
+     * Returns meetings scheduled for a team, ordered by start time. When `from`
+     * and/or `to` are supplied, only occurrences starting within that range are
+     * returned (used to load a single visible week).
      *
      * @param teamId Authentik group PK of the team
+     * @param from   ISO datetime; include occurrences starting at or after this
+     * @param to     ISO datetime; include occurrences starting before this
      */
     @Get("{teamId}/meetings")
     @Tags("Team Meetings")
@@ -78,17 +112,43 @@ export class MeetingsController extends Controller {
     @Security("oidc")
     async getTeamMeetings(
         @Path() teamId: string,
+        @Query() from?: Date,
+        @Query() to?: Date,
     ): Promise<APITeamMeetingResponse[]> {
-        return await TeamMeeting
-            .find({ teamPk: teamId })
-            .sort({ day: 1, start: 1 })
+        const filter: Record<string, unknown> = { teamPk: teamId };
+        if (from || to) {
+            const range: Record<string, Date> = {};
+            if (from) range.$gte = from;
+            if (to) range.$lt = to;
+            filter.start = range;
+        }
+
+        const meetings = await TeamMeeting
+            .find(filter)
+            .sort({ start: 1 })
             .lean()
-            .exec() as any as APITeamMeetingResponse[];
+            .exec();
+
+        /* `recurring` is derived, never stored: a series is recurring when more
+           than one occurrence shares its seriesId. The visible week may hold only
+           one occurrence of a series, so the count is resolved across all of them. */
+        const seriesIds = [...new Set(meetings.map((m) => m.seriesId))];
+        const counts = await TeamMeeting.aggregate<{ _id: string; count: number }>([
+            { $match: { seriesId: { $in: seriesIds } } },
+            { $group: { _id: "$seriesId", count: { $sum: 1 } } },
+        ]);
+        const seriesSize = new Map(counts.map((c) => [c._id, c.count]));
+
+        return meetings.map((m) => ({
+            ...m,
+            recurring: (seriesSize.get(m.seriesId) ?? 1) > 1,
+        })) as any as APITeamMeetingResponse[];
     }
 
     /**
      * Creates a new meeting for the given team.
-     * Requires the requesting user to be a Team Lead (or superuser) for the team.
+     * Requires the requesting user to be a Team Owner or hold the
+     * `corp:meetingsmgmt` bindle for the team.
      *
      * @param teamId Authentik group PK of the team
      * @param body   Meeting details
@@ -96,34 +156,60 @@ export class MeetingsController extends Controller {
     @Post("{teamId}/meetings")
     @Tags("Team Meetings")
     @SuccessResponse(201)
-    @Security("oidc")
+    @Security("bindles", ["corp:meetingsmgmt"])
     async createTeamMeeting(
         @Request() req: express.Request,
         @Path() teamId: string,
         @Body() body: APITeamMeetingCreateRequest,
-    ): Promise<APITeamMeetingResponse> {
-        if (body.start >= body.end) {
+    ): Promise<APITeamMeetingResponse[]> {
+        const start = new Date(body.start);
+        const end = new Date(body.end);
+        if (start.getTime() >= end.getTime()) {
             throw new CustomValidationError(400, "Meeting start time must be before end time");
         }
 
-        const meeting = await TeamMeeting.create({
+        let occurrences: Array<{ start: Date; end: Date }>;
+        if (body.recurring) {
+            /* Recurring meetings repeat weekly through the team's end date */
+            const teamInfo = await this.authentikClient.getGroupInfo(teamId);
+            const teamEndDate = teamInfo.attributes.teamEndDate;
+            if (!teamEndDate) {
+                throw new CustomValidationError(400, "Team has no end date set; cannot create a recurring meeting");
+            }
+            const until = new Date(`${teamEndDate}T23:59:59`);
+            if (until.getTime() < start.getTime()) {
+                throw new CustomValidationError(400, "Team end date is before the meeting start");
+            }
+            occurrences = generateWeeklyOccurrences(start, end, until);
+        } else {
+            occurrences = [{ start, end }];
+        }
+
+        const seriesId = randomUUID();
+        const docs = occurrences.map((occurrence) => ({
             teamPk:      teamId,
+            seriesId,
             name:        body.name,
             description: body.description ?? "",
-            day:         body.day,
-            start:       body.start,
-            end:         body.end,
+            start:       occurrence.start,
+            end:         occurrence.end,
             createdBy:   req.session.authorizedUser!.pk,
-        });
+        }));
+
+        const created = await TeamMeeting.insertMany(docs);
+
+        /* Derived for the response only — every doc just created shares one series. */
+        const recurring = created.length > 1;
 
         this.setStatus(201);
-        return meeting.toObject() as APITeamMeetingResponse;
+        return created.map((doc) => ({ ...doc.toObject(), recurring }) as APITeamMeetingResponse);
     }
 
     /**
      * Updates an existing team meeting. Only the fields provided in the
      * request body are changed.
-     * Requires the requesting user to be a Team Lead (or superuser) for the team.
+     * Requires the requesting user to be a Team Owner or hold the
+     * `corp:meetingsmgmt` bindle for the team.
      *
      * @param teamId    Authentik group PK of the team
      * @param meetingId MongoDB ObjectId of the meeting
@@ -132,48 +218,90 @@ export class MeetingsController extends Controller {
     @Patch("{teamId}/meetings/{meetingId}")
     @Tags("Team Meetings")
     @SuccessResponse(200)
-    @Security("oidc")
+    @Security("bindles", ["corp:meetingsmgmt"])
     async updateTeamMeeting(
         @Path() teamId: string,
         @Path() meetingId: string,
         @Body() body: APITeamMeetingUpdateRequest,
-    ): Promise<APITeamMeetingResponse> {
-        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId });
-        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
+    ): Promise<APITeamMeetingResponse[]> {
+        const target = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId });
+        if (!target) throw new CustomValidationError(404, "Meeting not found");
 
-        if (body.name        !== undefined) meeting.name        = body.name;
-        if (body.description !== undefined) meeting.description = body.description;
-        if (body.day         !== undefined) meeting.day         = body.day;
-        if (body.start       !== undefined) meeting.start       = body.start;
-        if (body.end         !== undefined) meeting.end         = body.end;
+        const newStart = body.start !== undefined ? new Date(body.start) : undefined;
+        const newEnd   = body.end   !== undefined ? new Date(body.end)   : undefined;
 
-        const effectiveStart = body.start ?? meeting.start;
-        const effectiveEnd   = body.end   ?? meeting.end;
-        if (effectiveStart >= effectiveEnd) {
+        const effectiveStart = newStart ?? target.start;
+        const effectiveEnd   = newEnd   ?? target.end;
+        if (effectiveStart.getTime() >= effectiveEnd.getTime()) {
             throw new CustomValidationError(400, "Meeting start time must be before end time");
         }
 
-        await meeting.save();
-        return meeting.toObject() as APITeamMeetingResponse;
+        /* A time edit moves/resizes the clicked occurrence; for "following"/"all"
+           the same start-of-day shift and duration are applied to each sibling so
+           they keep their own dates. Omitted fields fall back to the target's
+           current values, so a start-only or end-only edit still resizes correctly. */
+        const targetNewStart = newStart ?? target.start;
+        const targetNewEnd   = newEnd   ?? target.end;
+        const startDelta = targetNewStart.getTime() - target.start.getTime();
+        const duration   = targetNewEnd.getTime() - targetNewStart.getTime();
+        const timeChanged = newStart !== undefined || newEnd !== undefined;
+
+        /* Editing never reassigns seriesId. A "this"-scope edit therefore keeps the
+           occurrence linked to its series (standard calendar behavior: it can still
+           be swept by a later "following"/"all" edit) rather than detaching it. */
+        const scope: MeetingScope = body.scope ?? "this";
+        const filter: Record<string, unknown> = { seriesId: target.seriesId, teamPk: teamId };
+        if (scope === "this") {
+            filter._id = target._id;
+        } else if (scope === "following") {
+            filter.start = { $gte: target.start };
+        }
+
+        const occurrences = await TeamMeeting.find(filter);
+        for (const occurrence of occurrences) {
+            if (body.name        !== undefined) occurrence.name        = body.name;
+            if (body.description !== undefined) occurrence.description = body.description;
+            if (timeChanged) {
+                occurrence.start = new Date(occurrence.start.getTime() + startDelta);
+                occurrence.end   = new Date(occurrence.start.getTime() + duration);
+            }
+            await occurrence.save();
+        }
+
+        /* Series membership is unchanged by an edit, so a single count suffices. */
+        const recurring = await TeamMeeting.countDocuments({ seriesId: target.seriesId }) > 1;
+        return occurrences.map((occurrence) => ({ ...occurrence.toObject(), recurring }) as APITeamMeetingResponse);
     }
 
     /**
      * Permanently deletes a team meeting.
-     * Requires the requesting user to be a Team Lead (or superuser) for the team.
+     * Requires the requesting user to be a Team Owner or hold the
+     * `corp:meetingsmgmt` bindle for the team.
      *
      * @param teamId    Authentik group PK of the team
      * @param meetingId MongoDB ObjectId of the meeting
+     * @param scope     Which occurrences to remove (defaults to "this")
      */
     @Delete("{teamId}/meetings/{meetingId}")
     @Tags("Team Meetings")
     @SuccessResponse(204)
-    @Security("oidc")
+    @Security("bindles", ["corp:meetingsmgmt"])
     async deleteTeamMeeting(
         @Path() teamId: string,
         @Path() meetingId: string,
+        @Query() scope?: MeetingScope,
     ): Promise<void> {
-        const meeting = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId });
-        if (!meeting) throw new CustomValidationError(404, "Meeting not found");
-        await meeting.deleteOne();
+        const target = await TeamMeeting.findOne({ _id: meetingId, teamPk: teamId });
+        if (!target) throw new CustomValidationError(404, "Meeting not found");
+
+        const effectiveScope: MeetingScope = scope ?? "this";
+        const filter: Record<string, unknown> = { seriesId: target.seriesId, teamPk: teamId };
+        if (effectiveScope === "this") {
+            filter._id = target._id;
+        } else if (effectiveScope === "following") {
+            filter.start = { $gte: target.start };
+        }
+
+        await TeamMeeting.deleteMany(filter);
     }
 }

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -72,6 +72,8 @@ export interface APICreateTeamRequest {
     seasonType: SeasonType,
     seasonYear: number,
     description: string,
+    teamStartDate?: string,
+    teamEndDate: string,
     requestorRole: string
 }
 
@@ -80,8 +82,8 @@ interface APIUpdateTeamRequest {
     friendlyName?: string,
     /** @minLength 1 */
     description?: string,
-    /** @minLength 1 */
-    [key: string]: string
+    teamStartDate?: string,
+    teamEndDate?: string,
 }
 
 interface APITeamInfoResponse {
@@ -199,6 +201,23 @@ export class OrgController extends Controller {
         for (const teamSettingResource of Object.values(ENABLED_TEAMSETTING_RESOURCES)) {
             const resourceName = teamSettingResource.getResourceName()
             this.teamSettingList[resourceName] = teamSettingResource.getSupportedSettings()
+        }
+    }
+
+    private validateTeamDateRange(startDate: string, endDate: string) {
+        const parsedStart = new Date(startDate);
+        const parsedEnd = new Date(endDate);
+
+        if (Number.isNaN(parsedStart.getTime())) {
+            throw new CustomValidationError(400, "Invalid team start date");
+        }
+
+        if (Number.isNaN(parsedEnd.getTime())) {
+            throw new CustomValidationError(400, "Invalid team end date");
+        }
+
+        if (parsedStart > parsedEnd) {
+            throw new CustomValidationError(400, "Team start date must be on or before team end date");
         }
     }
 
@@ -1185,7 +1204,7 @@ export class OrgController extends Controller {
                 teamType: parentInfo.attributes.teamType,
                 seasonType: parentInfo.attributes.seasonType,
                 seasonYear: parentInfo.attributes.seasonYear,
-                description: body.description
+                description: body.description,
             }
         })
 
@@ -1332,6 +1351,8 @@ export class OrgController extends Controller {
         /* Santize Request */
         createTeamReq.friendlyName = validateTeamName(createTeamReq.friendlyName);
         createTeamReq.description = capitalizeString(createTeamReq.description);
+        createTeamReq.teamStartDate = createTeamReq.teamStartDate ?? new Date().toISOString().slice(0, 10);
+        this.validateTeamDateRange(createTeamReq.teamStartDate, createTeamReq.teamEndDate);
 
         /* Check for Authorized User */
         const authorizedUser = req.session.authorizedUser!;
@@ -1469,8 +1490,23 @@ export class OrgController extends Controller {
             conf.description = capitalizeString(conf.description);
         }
 
-        /* Strictly restrict updates to only name and description to prevent attribute pollution */
-        await this.authentikClient.updateGroupInformation(teamId, conf);
+        if (conf.teamStartDate !== undefined || conf.teamEndDate !== undefined) {
+            const teamInfo = await this.authentikClient.getGroupInfo(teamId);
+            const effectiveStartDate = conf.teamStartDate ?? teamInfo.attributes.teamStartDate;
+            const effectiveEndDate = conf.teamEndDate ?? teamInfo.attributes.teamEndDate;
+
+            if (!effectiveStartDate || !effectiveEndDate) {
+                throw new CustomValidationError(400, "Both team start date and end date are required");
+            }
+
+            this.validateTeamDateRange(
+                effectiveStartDate,
+                effectiveEndDate,
+            );
+        }
+
+        /* Strictly restrict updates to allowed fields to prevent attribute pollution */
+        await this.authentikClient.updateGroupInformation(teamId, conf as Record<string, string | undefined>);
     }
 
     /**
@@ -1528,7 +1564,17 @@ export class OrgController extends Controller {
         createTeamReq.friendlyName = validateTeamName(createTeamReq.friendlyName);
 
         /* Create the New Team */
-        const newTeam = await this.authentikClient.createNewTeam({ attributes: { ...createTeamReq } })
+        const newTeam = await this.authentikClient.createNewTeam({
+            attributes: {
+                friendlyName: createTeamReq.friendlyName,
+                teamType: createTeamReq.teamType,
+                seasonType: createTeamReq.seasonType,
+                seasonYear: createTeamReq.seasonYear,
+                description: createTeamReq.description,
+                teamStartDate: createTeamReq.teamStartDate ?? new Date().toISOString().slice(0, 10),
+                teamEndDate: createTeamReq.teamEndDate,
+            }
+        })
 
         /* Add the Creator to Team Owners */
         this.addTeamMemberWrapper({

--- a/src/models/Applicant.ts
+++ b/src/models/Applicant.ts
@@ -19,6 +19,7 @@
 import { Document, Schema, model } from "mongoose";
 
 export interface IApplicant extends Document {
+  _id: Schema.Types.ObjectId;
   email: string;
   fullName: string;
   profile: Map<string, string>; // Made required with default

--- a/src/models/MeetingAttendance.ts
+++ b/src/models/MeetingAttendance.ts
@@ -1,0 +1,61 @@
+/**
+  People Portal Server
+  Copyright (C) 2026  Atheesh Thirumalairajan
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Schema, model, Document } from 'mongoose';
+
+/** Whether an attendee is expected at the meeting or merely invited */
+export type AttendanceRole = 'required' | 'optional';
+
+/**
+ * One row of the attendance relation: links a single person (Authentik user PK)
+ * to a single meeting occurrence. Attendance is tracked per occurrence, so a
+ * recurring series produces one of these per attendee per week.
+ */
+export interface IMeetingAttendance extends Document {
+    /** MongoDB ObjectId (as string) of the TeamMeeting occurrence */
+    meetingId: string;
+    teamPk: string;
+    /** Mirrors the meeting's seriesId for convenient series-wide queries */
+    seriesId: string;
+    /** Authentik user PK of the attendee */
+    userPk: number;
+    role: AttendanceRole;
+    /** True once the attendee has been marked present; false until then */
+    present: boolean;
+    /** Authentik user PK of whoever last set attendance (self or a manager) */
+    markedBy: number | null;
+    markedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+const MeetingAttendanceSchema = new Schema<IMeetingAttendance>({
+    meetingId: { type: String, required: true, index: true },
+    teamPk:    { type: String, required: true, index: true },
+    seriesId:  { type: String, required: true, index: true },
+    userPk:    { type: Number, required: true, index: true },
+    role:      { type: String, enum: ['required', 'optional'], required: true },
+    present:   { type: Boolean, default: false },
+    markedBy:  { type: Number, default: null },
+    markedAt:  { type: Date, default: null },
+}, { timestamps: true });
+
+/* A person can appear at most once on a given meeting occurrence. */
+MeetingAttendanceSchema.index({ meetingId: 1, userPk: 1 }, { unique: true });
+
+export const MeetingAttendance = model<IMeetingAttendance>('MeetingAttendance', MeetingAttendanceSchema);

--- a/src/models/MeetingSubteamAttendance.ts
+++ b/src/models/MeetingSubteamAttendance.ts
@@ -1,0 +1,52 @@
+/**
+  People Portal Server
+  Copyright (C) 2026  Atheesh Thirumalairajan
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Schema, model, Document } from 'mongoose';
+import { AttendanceRole } from './MeetingAttendance';
+
+/**
+ * Invites an entire subteam to a meeting occurrence *by reference*: membership
+ * is resolved against Authentik at read/check-in time, so people who join or
+ * leave the subteam later are automatically included or excluded. Individual
+ * cross-subteam invitees live in MeetingAttendance instead.
+ */
+export interface IMeetingSubteamAttendance extends Document {
+    /** MongoDB ObjectId (as string) of the TeamMeeting occurrence */
+    meetingId: string;
+    teamPk: string;
+    /** Mirrors the meeting's seriesId for convenient series-wide queries */
+    seriesId: string;
+    /** Authentik group PK of the invited subteam */
+    subteamPk: string;
+    role: AttendanceRole;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+const MeetingSubteamAttendanceSchema = new Schema<IMeetingSubteamAttendance>({
+    meetingId: { type: String, required: true, index: true },
+    teamPk:    { type: String, required: true, index: true },
+    seriesId:  { type: String, required: true, index: true },
+    subteamPk: { type: String, required: true, index: true },
+    role:      { type: String, enum: ['required', 'optional'], required: true },
+}, { timestamps: true });
+
+/* A subteam can appear at most once on a given meeting occurrence. */
+MeetingSubteamAttendanceSchema.index({ meetingId: 1, subteamPk: 1 }, { unique: true });
+
+export const MeetingSubteamAttendance = model<IMeetingSubteamAttendance>('MeetingSubteamAttendance', MeetingSubteamAttendanceSchema);

--- a/src/models/TeamCreationRequest.ts
+++ b/src/models/TeamCreationRequest.ts
@@ -47,6 +47,8 @@ const TeamCreationRequestSchema: Schema = new Schema({
         teamType: { type: String, required: true },
         seasonType: { type: String, required: true },
         seasonYear: { type: Number, required: true },
+        teamStartDate: { type: String, required: true },
+        teamEndDate: { type: String, required: true },
         description: { type: String, required: true },
         requestorRole: { type: String, required: true }
     },

--- a/src/models/TeamMeeting.ts
+++ b/src/models/TeamMeeting.ts
@@ -28,6 +28,13 @@ export interface ITeamMeeting extends Document {
     end: Date;
     /** Authentik user PK of the person who created the meeting */
     createdBy: number;
+    /**
+     * When true, every team member sees this meeting on the calendar even if
+     * they are not invited. When false, non-managers only see it if they are
+     * invited (directly or via a subteam) or the meeting has no invite list
+     * at all (assumed general audience).
+     */
+    visibleToAll: boolean;
     createdAt: Date;
     updatedAt: Date;
 }
@@ -40,6 +47,7 @@ const TeamMeetingSchema = new Schema<ITeamMeeting>({
     start:       { type: Date, required: true },
     end:         { type: Date, required: true },
     createdBy:   { type: Number, required: true },
+    visibleToAll: { type: Boolean, default: false },
 }, { timestamps: true });
 
 export const TeamMeeting = model<ITeamMeeting>('TeamMeeting', TeamMeetingSchema);

--- a/src/models/TeamMeeting.ts
+++ b/src/models/TeamMeeting.ts
@@ -1,0 +1,47 @@
+/**
+  People Portal Server
+  Copyright (C) 2026  Atheesh Thirumalairajan
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Schema, model, Document } from 'mongoose';
+
+export interface ITeamMeeting extends Document {
+    teamPk: string;
+    name: string;
+    description: string;
+    /** 0 = Monday … 4 = Friday */
+    day: number;
+    /** Decimal hour, e.g. 9.5 = 9:30 AM */
+    start: number;
+    /** Decimal hour, e.g. 10.5 = 10:30 AM */
+    end: number;
+    /** Authentik user PK of the person who created the meeting */
+    createdBy: number;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+const TeamMeetingSchema = new Schema<ITeamMeeting>({
+    teamPk:      { type: String, required: true, index: true },
+    name:        { type: String, required: true },
+    description: { type: String, default: '' },
+    day:         { type: Number, required: true, min: 0, max: 4 },
+    start:       { type: Number, required: true },
+    end:         { type: Number, required: true },
+    createdBy:   { type: Number, required: true },
+}, { timestamps: true });
+
+export const TeamMeeting = model<ITeamMeeting>('TeamMeeting', TeamMeetingSchema);

--- a/src/models/TeamMeeting.ts
+++ b/src/models/TeamMeeting.ts
@@ -20,14 +20,12 @@ import { Schema, model, Document } from 'mongoose';
 
 export interface ITeamMeeting extends Document {
     teamPk: string;
+    /** Groups all occurrences generated from one create request */
+    seriesId: string;
     name: string;
     description: string;
-    /** 0 = Monday … 4 = Friday */
-    day: number;
-    /** Decimal hour, e.g. 9.5 = 9:30 AM */
-    start: number;
-    /** Decimal hour, e.g. 10.5 = 10:30 AM */
-    end: number;
+    start: Date;
+    end: Date;
     /** Authentik user PK of the person who created the meeting */
     createdBy: number;
     createdAt: Date;
@@ -36,11 +34,11 @@ export interface ITeamMeeting extends Document {
 
 const TeamMeetingSchema = new Schema<ITeamMeeting>({
     teamPk:      { type: String, required: true, index: true },
+    seriesId:    { type: String, required: true, index: true },
     name:        { type: String, required: true },
     description: { type: String, default: '' },
-    day:         { type: Number, required: true, min: 0, max: 4 },
-    start:       { type: Number, required: true },
-    end:         { type: Number, required: true },
+    start:       { type: Date, required: true },
+    end:         { type: Date, required: true },
     createdBy:   { type: Number, required: true },
 }, { timestamps: true });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -10,6 +10,8 @@ import { BindleController } from './controllers/BindleController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrgController } from './controllers/OrgController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { MeetingsController } from './controllers/MeetingsController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { HooksController } from './controllers/HooksController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AuthController } from './controllers/AuthController';
@@ -385,6 +387,47 @@ const models: TsoaRoute.Models = {
         "additionalProperties": {"dataType":"string"},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APITeamMeetingResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "_id": {"dataType":"string","required":true},
+            "teamPk": {"dataType":"string","required":true},
+            "name": {"dataType":"string","required":true},
+            "description": {"dataType":"string","required":true},
+            "day": {"dataType":"double","required":true},
+            "start": {"dataType":"double","required":true},
+            "end": {"dataType":"double","required":true},
+            "createdBy": {"dataType":"double","required":true},
+            "createdAt": {"dataType":"datetime","required":true},
+            "updatedAt": {"dataType":"datetime","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APITeamMeetingCreateRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true,"validators":{"minLength":{"value":1}}},
+            "description": {"dataType":"string"},
+            "day": {"dataType":"double","required":true,"validators":{"minimum":{"value":0},"maximum":{"value":4}}},
+            "start": {"dataType":"double","required":true},
+            "end": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APITeamMeetingUpdateRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","validators":{"minLength":{"value":1}}},
+            "description": {"dataType":"string"},
+            "day": {"dataType":"double","validators":{"minimum":{"value":0},"maximum":{"value":4}}},
+            "start": {"dataType":"double"},
+            "end": {"dataType":"double"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "GiteaRepositoryPermissions": {
         "dataType": "refObject",
         "properties": {
@@ -642,7 +685,7 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Required___id-mongoose.Types.ObjectId__": {
+    "Required___id-mongoose.FlattenMaps_unknown___": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
@@ -700,11 +743,6 @@ const models: TsoaRoute.Models = {
             "notes": {"dataType":"string"},
         },
         "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "mongoose.Types.ObjectId": {
-        "dataType": "refAlias",
-        "type": {"dataType":"string","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ATSUpdateApplicationStageRequest": {
@@ -1724,6 +1762,135 @@ export function RegisterRoutes(app: Router) {
                 next,
                 validatedArgs,
                 successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_getTeamMeetings: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+        };
+        app.get('/api/org/teams/:teamId/meetings',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.getTeamMeetings)),
+
+            async function MeetingsController_getTeamMeetings(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_getTeamMeetings, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'getTeamMeetings',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_createTeamMeeting: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"ref":"APITeamMeetingCreateRequest"},
+        };
+        app.post('/api/org/teams/:teamId/meetings',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.createTeamMeeting)),
+
+            async function MeetingsController_createTeamMeeting(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_createTeamMeeting, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'createTeamMeeting',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_updateTeamMeeting: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"ref":"APITeamMeetingUpdateRequest"},
+        };
+        app.patch('/api/org/teams/:teamId/meetings/:meetingId',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.updateTeamMeeting)),
+
+            async function MeetingsController_updateTeamMeeting(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_updateTeamMeeting, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'updateTeamMeeting',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_deleteTeamMeeting: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+        };
+        app.delete('/api/org/teams/:teamId/meetings/:meetingId',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.deleteTeamMeeting)),
+
+            async function MeetingsController_deleteTeamMeeting(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_deleteTeamMeeting, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'deleteTeamMeeting',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 204,
               });
             } catch (err) {
                 return next(err);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -166,6 +166,8 @@ const models: TsoaRoute.Models = {
             "teamType": {"ref":"TeamType","required":true},
             "seasonType": {"dataType":"union","subSchemas":[{"ref":"SeasonType"},{"ref":"ServiceSeasonType"}],"required":true},
             "seasonYear": {"dataType":"double","required":true},
+            "teamStartDate": {"dataType":"string","required":true},
+            "teamEndDate": {"dataType":"string","required":true},
             "peoplePortalCreation": {"dataType":"boolean"},
             "flaggedForDeletion": {"dataType":"boolean"},
             "description": {"dataType":"string","required":true},
@@ -319,6 +321,8 @@ const models: TsoaRoute.Models = {
             "teamType": {"ref":"TeamType","required":true},
             "seasonType": {"dataType":"union","subSchemas":[{"ref":"SeasonType"},{"ref":"ServiceSeasonType"}],"required":true},
             "seasonYear": {"dataType":"double","required":true},
+            "teamStartDate": {"dataType":"string","required":true},
+            "teamEndDate": {"dataType":"string","required":true},
             "peoplePortalCreation": {"dataType":"boolean"},
             "flaggedForDeletion": {"dataType":"boolean"},
             "description": {"dataType":"string","required":true},
@@ -354,6 +358,8 @@ const models: TsoaRoute.Models = {
             "seasonType": {"ref":"SeasonType","required":true},
             "seasonYear": {"dataType":"double","required":true},
             "description": {"dataType":"string","required":true},
+            "teamStartDate": {"dataType":"string"},
+            "teamEndDate": {"dataType":"string","required":true},
             "requestorRole": {"dataType":"string","required":true},
         },
         "additionalProperties": false,
@@ -383,8 +389,10 @@ const models: TsoaRoute.Models = {
         "properties": {
             "friendlyName": {"dataType":"string","validators":{"minLength":{"value":1}}},
             "description": {"dataType":"string","validators":{"minLength":{"value":1}}},
+            "teamStartDate": {"dataType":"string"},
+            "teamEndDate": {"dataType":"string"},
         },
-        "additionalProperties": {"dataType":"string"},
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "APITeamMeetingResponse": {
@@ -392,11 +400,12 @@ const models: TsoaRoute.Models = {
         "properties": {
             "_id": {"dataType":"string","required":true},
             "teamPk": {"dataType":"string","required":true},
+            "seriesId": {"dataType":"string","required":true},
+            "recurring": {"dataType":"boolean","required":true},
             "name": {"dataType":"string","required":true},
             "description": {"dataType":"string","required":true},
-            "day": {"dataType":"double","required":true},
-            "start": {"dataType":"double","required":true},
-            "end": {"dataType":"double","required":true},
+            "start": {"dataType":"datetime","required":true},
+            "end": {"dataType":"datetime","required":true},
             "createdBy": {"dataType":"double","required":true},
             "createdAt": {"dataType":"datetime","required":true},
             "updatedAt": {"dataType":"datetime","required":true},
@@ -407,23 +416,28 @@ const models: TsoaRoute.Models = {
     "APITeamMeetingCreateRequest": {
         "dataType": "refObject",
         "properties": {
-            "name": {"dataType":"string","required":true,"validators":{"minLength":{"value":1}}},
+            "name": {"dataType":"string","required":true},
             "description": {"dataType":"string"},
-            "day": {"dataType":"double","required":true,"validators":{"minimum":{"value":0},"maximum":{"value":4}}},
-            "start": {"dataType":"double","required":true},
-            "end": {"dataType":"double","required":true},
+            "start": {"dataType":"datetime","required":true},
+            "end": {"dataType":"datetime","required":true},
+            "recurring": {"dataType":"boolean"},
         },
         "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MeetingScope": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["this"]},{"dataType":"enum","enums":["following"]},{"dataType":"enum","enums":["all"]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "APITeamMeetingUpdateRequest": {
         "dataType": "refObject",
         "properties": {
-            "name": {"dataType":"string","validators":{"minLength":{"value":1}}},
+            "name": {"dataType":"string"},
             "description": {"dataType":"string"},
-            "day": {"dataType":"double","validators":{"minimum":{"value":0},"maximum":{"value":4}}},
-            "start": {"dataType":"double"},
-            "end": {"dataType":"double"},
+            "start": {"dataType":"datetime"},
+            "end": {"dataType":"datetime"},
+            "scope": {"ref":"MeetingScope"},
         },
         "additionalProperties": false,
     },
@@ -1770,6 +1784,8 @@ export function RegisterRoutes(app: Router) {
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsMeetingsController_getTeamMeetings: Record<string, TsoaRoute.ParameterSchema> = {
                 teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                from: {"in":"query","name":"from","dataType":"datetime"},
+                to: {"in":"query","name":"to","dataType":"datetime"},
         };
         app.get('/api/org/teams/:teamId/meetings',
             authenticateMiddleware([{"oidc":[]}]),
@@ -1805,7 +1821,7 @@ export function RegisterRoutes(app: Router) {
                 body: {"in":"body","name":"body","required":true,"ref":"APITeamMeetingCreateRequest"},
         };
         app.post('/api/org/teams/:teamId/meetings',
-            authenticateMiddleware([{"oidc":[]}]),
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
             ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
             ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.createTeamMeeting)),
 
@@ -1838,7 +1854,7 @@ export function RegisterRoutes(app: Router) {
                 body: {"in":"body","name":"body","required":true,"ref":"APITeamMeetingUpdateRequest"},
         };
         app.patch('/api/org/teams/:teamId/meetings/:meetingId',
-            authenticateMiddleware([{"oidc":[]}]),
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
             ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
             ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.updateTeamMeeting)),
 
@@ -1868,9 +1884,10 @@ export function RegisterRoutes(app: Router) {
         const argsMeetingsController_deleteTeamMeeting: Record<string, TsoaRoute.ParameterSchema> = {
                 teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
                 meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                scope: {"in":"query","name":"scope","ref":"MeetingScope"},
         };
         app.delete('/api/org/teams/:teamId/meetings/:meetingId',
-            authenticateMiddleware([{"oidc":[]}]),
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
             ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
             ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.deleteTeamMeeting)),
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -166,8 +166,8 @@ const models: TsoaRoute.Models = {
             "teamType": {"ref":"TeamType","required":true},
             "seasonType": {"dataType":"union","subSchemas":[{"ref":"SeasonType"},{"ref":"ServiceSeasonType"}],"required":true},
             "seasonYear": {"dataType":"double","required":true},
-            "teamStartDate": {"dataType":"string","required":true},
-            "teamEndDate": {"dataType":"string","required":true},
+            "teamStartDate": {"dataType":"string"},
+            "teamEndDate": {"dataType":"string"},
             "peoplePortalCreation": {"dataType":"boolean"},
             "flaggedForDeletion": {"dataType":"boolean"},
             "description": {"dataType":"string","required":true},
@@ -321,8 +321,8 @@ const models: TsoaRoute.Models = {
             "teamType": {"ref":"TeamType","required":true},
             "seasonType": {"dataType":"union","subSchemas":[{"ref":"SeasonType"},{"ref":"ServiceSeasonType"}],"required":true},
             "seasonYear": {"dataType":"double","required":true},
-            "teamStartDate": {"dataType":"string","required":true},
-            "teamEndDate": {"dataType":"string","required":true},
+            "teamStartDate": {"dataType":"string"},
+            "teamEndDate": {"dataType":"string"},
             "peoplePortalCreation": {"dataType":"boolean"},
             "flaggedForDeletion": {"dataType":"boolean"},
             "description": {"dataType":"string","required":true},
@@ -407,6 +407,7 @@ const models: TsoaRoute.Models = {
             "start": {"dataType":"datetime","required":true},
             "end": {"dataType":"datetime","required":true},
             "createdBy": {"dataType":"double","required":true},
+            "visibleToAll": {"dataType":"boolean","required":true},
             "createdAt": {"dataType":"datetime","required":true},
             "updatedAt": {"dataType":"datetime","required":true},
         },
@@ -421,6 +422,11 @@ const models: TsoaRoute.Models = {
             "start": {"dataType":"datetime","required":true},
             "end": {"dataType":"datetime","required":true},
             "recurring": {"dataType":"boolean"},
+            "requiredAttendees": {"dataType":"array","array":{"dataType":"double"}},
+            "optionalAttendees": {"dataType":"array","array":{"dataType":"double"}},
+            "requiredSubteams": {"dataType":"array","array":{"dataType":"string"}},
+            "optionalSubteams": {"dataType":"array","array":{"dataType":"string"}},
+            "visibleToAll": {"dataType":"boolean"},
         },
         "additionalProperties": false,
     },
@@ -437,7 +443,107 @@ const models: TsoaRoute.Models = {
             "description": {"dataType":"string"},
             "start": {"dataType":"datetime"},
             "end": {"dataType":"datetime"},
+            "visibleToAll": {"dataType":"boolean"},
             "scope": {"ref":"MeetingScope"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIMeetingRosterMember": {
+        "dataType": "refObject",
+        "properties": {
+            "pk": {"dataType":"double","required":true},
+            "name": {"dataType":"string","required":true},
+            "username": {"dataType":"string","required":true},
+            "email": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AttendanceRole": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["required"]},{"dataType":"enum","enums":["optional"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIMyAttendanceItem": {
+        "dataType": "refObject",
+        "properties": {
+            "_id": {"dataType":"string","required":true},
+            "teamPk": {"dataType":"string","required":true},
+            "seriesId": {"dataType":"string","required":true},
+            "recurring": {"dataType":"boolean","required":true},
+            "name": {"dataType":"string","required":true},
+            "description": {"dataType":"string","required":true},
+            "start": {"dataType":"datetime","required":true},
+            "end": {"dataType":"datetime","required":true},
+            "createdBy": {"dataType":"double","required":true},
+            "visibleToAll": {"dataType":"boolean","required":true},
+            "createdAt": {"dataType":"datetime","required":true},
+            "updatedAt": {"dataType":"datetime","required":true},
+            "role": {"ref":"AttendanceRole","required":true},
+            "present": {"dataType":"boolean","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIMeetingAttendee": {
+        "dataType": "refObject",
+        "properties": {
+            "userPk": {"dataType":"double","required":true},
+            "name": {"dataType":"string","required":true},
+            "role": {"ref":"AttendanceRole","required":true},
+            "present": {"dataType":"boolean","required":true},
+            "markedBy": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
+            "markedAt": {"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},
+            "explicit": {"dataType":"boolean","required":true},
+            "viaSubteam": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIMeetingSubteamRef": {
+        "dataType": "refObject",
+        "properties": {
+            "subteamPk": {"dataType":"string","required":true},
+            "name": {"dataType":"string","required":true},
+            "role": {"ref":"AttendanceRole","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIMeetingAttendanceResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "viewerPk": {"dataType":"double","required":true},
+            "canManage": {"dataType":"boolean","required":true},
+            "attendees": {"dataType":"array","array":{"dataType":"refObject","ref":"APIMeetingAttendee"},"required":true},
+            "subteams": {"dataType":"array","array":{"dataType":"refObject","ref":"APIMeetingSubteamRef"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIAddAttendeeRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "userPk": {"dataType":"double","required":true},
+            "role": {"ref":"AttendanceRole"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIAddSubteamRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "subteamPk": {"dataType":"string","required":true},
+            "role": {"ref":"AttendanceRole"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "APIMarkAttendanceRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "present": {"dataType":"boolean","required":true},
         },
         "additionalProperties": false,
     },
@@ -1783,6 +1889,7 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsMeetingsController_getTeamMeetings: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
                 teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
                 from: {"in":"query","name":"from","dataType":"datetime"},
                 to: {"in":"query","name":"to","dataType":"datetime"},
@@ -1903,6 +2010,369 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'deleteTeamMeeting',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 204,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_getMeetingRoster: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+        };
+        app.get('/api/org/teams/:teamId/meetings/roster',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.getMeetingRoster)),
+
+            async function MeetingsController_getMeetingRoster(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_getMeetingRoster, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'getMeetingRoster',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_getMeetingCapabilities: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+        };
+        app.get('/api/org/teams/:teamId/meetings/capabilities',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.getMeetingCapabilities)),
+
+            async function MeetingsController_getMeetingCapabilities(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_getMeetingCapabilities, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'getMeetingCapabilities',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_getMyAttendance: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                from: {"in":"query","name":"from","dataType":"datetime"},
+                to: {"in":"query","name":"to","dataType":"datetime"},
+        };
+        app.get('/api/org/teams/:teamId/meetings/mine',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.getMyAttendance)),
+
+            async function MeetingsController_getMyAttendance(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_getMyAttendance, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'getMyAttendance',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_getTeamMeeting: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+        };
+        app.get('/api/org/teams/:teamId/meetings/:meetingId',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.getTeamMeeting)),
+
+            async function MeetingsController_getTeamMeeting(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_getTeamMeeting, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'getTeamMeeting',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_checkInToMeeting: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+        };
+        app.post('/api/org/teams/:teamId/meetings/:meetingId/checkin',
+            authenticateMiddleware([{"oidc":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.checkInToMeeting)),
+
+            async function MeetingsController_checkInToMeeting(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_checkInToMeeting, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'checkInToMeeting',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_getMeetingAttendance: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+        };
+        app.get('/api/org/teams/:teamId/meetings/:meetingId/attendance',
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.getMeetingAttendance)),
+
+            async function MeetingsController_getMeetingAttendance(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_getMeetingAttendance, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'getMeetingAttendance',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_addMeetingAttendee: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"ref":"APIAddAttendeeRequest"},
+        };
+        app.post('/api/org/teams/:teamId/meetings/:meetingId/attendance',
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.addMeetingAttendee)),
+
+            async function MeetingsController_addMeetingAttendee(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_addMeetingAttendee, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'addMeetingAttendee',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_addMeetingSubteam: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"ref":"APIAddSubteamRequest"},
+        };
+        app.post('/api/org/teams/:teamId/meetings/:meetingId/attendance/subteams',
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.addMeetingSubteam)),
+
+            async function MeetingsController_addMeetingSubteam(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_addMeetingSubteam, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'addMeetingSubteam',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_removeMeetingSubteam: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                subteamPk: {"in":"path","name":"subteamPk","required":true,"dataType":"string"},
+        };
+        app.delete('/api/org/teams/:teamId/meetings/:meetingId/attendance/subteams/:subteamPk',
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.removeMeetingSubteam)),
+
+            async function MeetingsController_removeMeetingSubteam(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_removeMeetingSubteam, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'removeMeetingSubteam',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 204,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_markAttendance: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                userPk: {"in":"path","name":"userPk","required":true,"dataType":"double"},
+                body: {"in":"body","name":"body","required":true,"ref":"APIMarkAttendanceRequest"},
+        };
+        app.patch('/api/org/teams/:teamId/meetings/:meetingId/attendance/:userPk',
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.markAttendance)),
+
+            async function MeetingsController_markAttendance(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_markAttendance, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'markAttendance',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMeetingsController_removeMeetingAttendee: Record<string, TsoaRoute.ParameterSchema> = {
+                teamId: {"in":"path","name":"teamId","required":true,"dataType":"string"},
+                meetingId: {"in":"path","name":"meetingId","required":true,"dataType":"string"},
+                userPk: {"in":"path","name":"userPk","required":true,"dataType":"double"},
+        };
+        app.delete('/api/org/teams/:teamId/meetings/:meetingId/attendance/:userPk',
+            authenticateMiddleware([{"bindles":["corp:meetingsmgmt"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController)),
+            ...(fetchMiddlewares<RequestHandler>(MeetingsController.prototype.removeMeetingAttendee)),
+
+            async function MeetingsController_removeMeetingAttendee(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMeetingsController_removeMeetingAttendee, request, response });
+
+                const controller = new MeetingsController();
+
+              await templateService.apiHandler({
+                methodName: 'removeMeetingAttendee',
                 controller,
                 response,
                 next,


### PR DESCRIPTION
## Description
Adds the backend for **Team Meetings**: a new `MeetingsController` exposing CRUD endpoints for scheduling meetings against a team, with support for weekly recurring series, attendance tracking with QR self check-in, subteam invites by reference, and per-meeting visibility. Also adds team start/end dates to `OrgController` (validated on team creation/update), which bound how far recurring meetings repeat.

Endpoints (all under `/api/org/teams/{teamId}/meetings`):
- `GET  /meetings`: list meetings ordered by start time, optionally filtered to a `from`/`to` window; `recurring` is derived from how many occurrences share a `seriesId`. Non-managers only see meetings that are marked visible-to-all, have no invite list at all (assumed general audience), or that they are invited to — directly or through one of their subteams.
- `POST /meetings`: create a single meeting or, when `recurring` is set, a weekly series through the team's end date. Accepts required/optional individual attendees (`requiredAttendees`/`optionalAttendees`), required/optional subteam invites (`requiredSubteams`/`optionalSubteams`), and a `visibleToAll` flag.
- `PATCH /meetings/{meetingId}`: update name/description/time/`visibleToAll` with `this` / `following` / `all` scope; time edits apply the same shift and duration to affected siblings.
- `DELETE /meetings/{meetingId}`: delete with the same `this` / `following` / `all` scope; attendance rows and subteam invites for the removed occurrences are cleaned up.
- `GET  /meetings/{meetingId}`: fetch one occurrence (detail/check-in pages). Enforces the same visibility predicate as the list, returning 404 so hidden meetings can't be probed.
- `GET  /meetings/roster`: flattened team + subteam member roster for the attendee picker.
- `GET  /meetings/capabilities`: whether the requester may manage meetings (drives UI gating).
- `GET  /meetings/mine`: the requester's own meetings and attendance status, including meetings they're covered by via a subteam invite.
- `POST /meetings/{meetingId}/checkin`: QR self check-in. Open for the meeting's calendar day; upserts the caller's attendance row atomically, inheriting the role from a covering subteam invite (else `optional`). Non-members are rejected.
- `GET / POST /meetings/{meetingId}/attendance`: the attendance sheet (managers only). Returns explicit rows merged with live-resolved members of invited subteams (`explicit` / `viaSubteam` markers) plus the invited-subteam list; `POST` adds an individual attendee.
- `PATCH / DELETE /meetings/{meetingId}/attendance/{userPk}`: mark present/absent (atomically materializes a row for subteam invitees on first mark) / remove an individually invited attendee.
- `POST / DELETE /meetings/{meetingId}/attendance/subteams[/{subteamPk}]`: invite or uninvite a whole subteam.

New models:
- `MeetingAttendance`: one row per person per occurrence (`role`, `present`, `markedBy`/`markedAt`), unique on `(meetingId, userPk)`.
- `MeetingSubteamAttendance`: subteam invites stored **by reference** (`subteamPk` only) — membership is resolved against Authentik at read/check-in time, so invites automatically track subteams as they grow or shrink. Individual invites remain for people outside the invited subteams.
- `TeamMeeting.visibleToAll`: per-meeting toggle for whether uninvited members can see it.

Authorization: mutations and the attendance sheet require Team Owner, executive, superuser, or the `corp:meetingsmgmt` bindle. Duplicate adds and concurrent check-in/mark races resolve via the unique indexes (409 instead of 500). Authentik group lookups are memoized per request to avoid N+1 fan-out. `/api/auth/login?return_to=` now only accepts same-host or relative targets (open-redirect hardening for the QR login bounce).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Chore / dependency update

## Testing
<!-- How did you test this? What should reviewers check? -->
Reviewers should verify:
- Recurring creation stops at the team end date and rejects when no end date is set or the end date precedes the start.
- `start < end` validation on create and update.
- Scope handling (`this` / `following` / `all`) for both update and delete, and that edits never reassign `seriesId`.
- Team date-range validation in `OrgController` (invalid dates, start after end) on create and update.
- Creating a top-level team still requires `teamEndDate`; creating a sub-team succeeds without any dates, and the created sub-team carries no `teamStartDate`/`teamEndDate`.
- Authorization via the `corp:meetingsmgmt` bindle / Team Owner.
- Visibility matrix on `GET /meetings` and `GET /meetings/{meetingId}`: manager sees all; non-manager sees visible-to-all, uninvited, directly invited, and subteam-invited meetings only; hidden meetings return 404 on direct fetch.
- Subteam invites resolve current membership: someone joining an invited subteam after the invite appears on the sheet and can check in with the subteam's role; someone leaving disappears (unless their row was already materialized).
- Check-in window (calendar day of the meeting), rejection of non-members, and that re-scans don't error (atomic upsert).
- Marking a subteam invitee present materializes their row once, including under a concurrent self check-in (no duplicate-key 500).

## Screenshots
N/A, backend only.

## Checklist
- [x] Self-reviewed my own code
- [x] No console.log / debug statements left in
- [x] Tested locally
