### PR TITLE
  Cache open teams endpoint in Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ PEOPLEPORTAL_OIDC_CLIENTSECRET=your-oidc-client-secret
 # Server
 PEOPLEPORTAL_BASE_URL=http://localhost:3000
 PEOPLEPORTAL_MONGO_URL=mongodb://localhost:27017/people-portal
+PEOPLEPORTAL_REDIS_URL=redis://localhost:6379
 
 # Gitea
 PEOPLEPORTAL_GITEA_ENDPOINT=http://localhost:10000

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "nodemailer": "^7.0.6",
         "nodemailer-express-handlebars": "^7.0.0",
         "openid-client": "^6.7.1",
+        "redis": "^6.0.1",
         "tsoa": "^6.6.0",
         "zxcvbn": "^4.4.2"
       },
@@ -1187,6 +1188,78 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.0.1.tgz",
+      "integrity": "sha512-6ys5hhea+47n7o97ZFI4GvdzTQk/arIsXZgH159l6IVtJ4rZaB+KVdAfwvIxlmGA7z+NNlO8UxjTeQrenqjZcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.1.tgz",
+      "integrity": "sha512-SwYl64hKHE/NeO2VSSG1y/4zIm0cNepyOZtQrOpLiNRHmH2FdWBOecNzsLiXCQdFCF9MCyoPXwAbaG2iMO0A7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.0.1.tgz",
+      "integrity": "sha512-KD1OztCYh7O9TkKMU9qZcFIKoudIGqmgXsOhQVq5A3REGrnl+wg0kporQFQCO+fcxe/nhvDgmBtXrm3diPGczA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.0.1.tgz",
+      "integrity": "sha512-G09OujS3eOtQnP7kZC5eZTiazwgeimlo6Pf3vHnE1jO7rfqrtmMI0R1/ZXfzoW8p9vB4QiH538aEsWaHKd8l5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.0.1.tgz",
+      "integrity": "sha512-8aLGSDtCpnPTLD7lEiHHmuDCFppctLdT8geFIDf/7LWV9y8Vre6RB+aBZrgkeo3X1oPmTt1IbVAQVxsuJvkODw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.1"
       }
     },
     "node_modules/@scalar/core": {
@@ -2686,6 +2759,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/collection-visit": {
@@ -6105,6 +6187,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.0.1.tgz",
+      "integrity": "sha512-54FoTBdFw10Y602pShvk8CGJlSH55nY+CNAZaVk8YdxY3rENihdYm2lXrujrtupYTHyrVSZUxOdeStNQbNvnQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "6.0.1",
+        "@redis/client": "6.0.1",
+        "@redis/json": "6.0.1",
+        "@redis/search": "6.0.1",
+        "@redis/time-series": "6.0.1"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nodemailer": "^7.0.6",
     "nodemailer-express-handlebars": "^7.0.0",
     "openid-client": "^6.7.1",
+    "redis": "^6.0.1",
     "tsoa": "^6.6.0",
     "zxcvbn": "^4.4.2"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,7 @@ import { generateSecureRandomString } from "./utils/strings";
 import path from "path";
 import { NativeExpressOIDCAuthPort } from "./auth";
 import { AuthentikClient } from "./clients/AuthentikClient";
+import { RedisClient } from "./clients/RedisClient";
 import { CustomValidationError, ResourceAccessError } from "./utils/errors";
 import { ENABLED_SHARED_RESOURCES } from "./config";
 import log from 'loglevel';
@@ -158,6 +159,7 @@ app.use(function errorHandler(
 app.listen(PORT, async () => {
   /* Validate Connections */
   await OpenIdClient.init()
+  await RedisClient.init()
   //await AuthentikClient.validateAuthentikConnection()
 
   /* Validate Service Team Creation */

--- a/src/clients/RedisClient/index.ts
+++ b/src/clients/RedisClient/index.ts
@@ -1,0 +1,54 @@
+import { createClient } from "redis";
+
+export class RedisClient {
+    private static client: ReturnType<typeof createClient> | null = null;
+
+    private static getRedisUrl(): string {
+        const redisUrl = process.env.PEOPLEPORTAL_REDIS_URL;
+        if (!redisUrl) {
+            throw new Error("Redis URL is invalid");
+        }
+
+        return redisUrl;
+    }
+
+    private static getClient() {
+        if (!this.client) {
+            this.client = createClient({ url: this.getRedisUrl() });
+        }
+
+        return this.client;
+    }
+
+    public static async init() {
+        const client = this.getClient();
+        if (!client.isOpen) {
+            await client.connect();
+        }
+    }
+
+    public static async get<T>(key: string): Promise<T | null> {
+        const value = await this.getClient().get(key);
+
+        if (!value) {
+            return null;
+        }
+
+        return JSON.parse(value) as T;
+    }
+
+    public static async set(key: string, value: unknown, ttlSeconds?: number) {
+        const serializedValue = JSON.stringify(value);
+
+        if (ttlSeconds) {
+            await this.getClient().set(key, serializedValue, { EX: ttlSeconds });
+            return;
+        }
+
+        await this.getClient().set(key, serializedValue);
+    }
+
+    public static async delete(key: string) {
+        await this.getClient().del(key);
+    }
+}

--- a/src/controllers/ATSController.ts
+++ b/src/controllers/ATSController.ts
@@ -36,6 +36,7 @@ import { OrgController } from "./OrgController";
 import { AuthorizedUser } from "../clients/OpenIdClient";
 import { validateS3FileSignature, FILE_SIGNATURES } from '../utils/s3-validation';
 import MarkdownIt from "markdown-it";
+import { RedisClient } from "../clients/RedisClient";
 
 // ====================
 // Type Definitions
@@ -99,6 +100,7 @@ const ALLOWED_CONTENT_TYPES = ['application/pdf'] as const;
 const MAX_RESPONSE_LENGTH = 2000;
 const MAX_WHY_APPDEV_WORDS = 200;
 const MIN_RESPONSE_WORDS = 10;
+const OPEN_TEAMS_CACHE_KEY = "ats:openteams";
 
 @Route("/api/ats")
 export class ATSController extends Controller {
@@ -366,6 +368,11 @@ export class ATSController extends Controller {
     @Tags("Applicant Portal")
     @SuccessResponse(200)
     async getAllRecruitingTeams() {
+        const cachedOpenTeams = await RedisClient.get<any[]>(OPEN_TEAMS_CACHE_KEY);
+        if (cachedOpenTeams) {
+            return cachedOpenTeams;
+        }
+
         /* Fetch All teams that are recruiting currently */
         const recruitingTeams: any[] = await TeamRecruitingStatus.find({ isRecruiting: true }).lean().exec();
 
@@ -433,6 +440,7 @@ export class ATSController extends Controller {
             }
         }
 
+        await RedisClient.set(OPEN_TEAMS_CACHE_KEY, validRecruitingTeams);
         return validRecruitingTeams;
     }
 
@@ -1415,6 +1423,8 @@ export class ATSController extends Controller {
 
     /* === HELPER METHODS === */
     async addSubteamToRecruiting(@Path() teamId: string, @Path() subteamId: string) {
+        await RedisClient.delete(OPEN_TEAMS_CACHE_KEY);
+
         const updatedTeam = await TeamRecruitingStatus.findOneAndUpdate(
             { teamPk: teamId },
             {
@@ -1437,6 +1447,8 @@ export class ATSController extends Controller {
     }
 
     async removeSubteamFromRecruiting(@Path() teamId: string, @Path() subteamId: string) {
+        await RedisClient.delete(OPEN_TEAMS_CACHE_KEY);
+
         const updatedTeam = await TeamRecruitingStatus.findOneAndUpdate(
             { teamPk: teamId },
             { $pull: { recruitingSubteamPks: subteamId } },

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -292,7 +292,7 @@ export class AuthController extends Controller {
 
         // Generate JWT
         const token = jwt.sign(
-            { email, name: applicant.fullName, id: applicant._id },
+            { email, name: applicant.fullName, id: String(applicant._id) },
             process.env.PEOPLEPORTAL_TOKEN_SECRET!,
             { expiresIn: "24h" }
         );
@@ -303,7 +303,7 @@ export class AuthController extends Controller {
             user: {
                 email: applicant.email,
                 name: applicant.fullName,
-                id: applicant._id.toString()
+                id: String(applicant._id)
             }
         }
 

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -292,7 +292,7 @@ export class AuthController extends Controller {
 
         // Generate JWT
         const token = jwt.sign(
-            { email, name: applicant.fullName, id: String(applicant._id) },
+            { email, name: applicant.fullName, id: applicant._id },
             process.env.PEOPLEPORTAL_TOKEN_SECRET!,
             { expiresIn: "24h" }
         );
@@ -303,7 +303,7 @@ export class AuthController extends Controller {
             user: {
                 email: applicant.email,
                 name: applicant.fullName,
-                id: String(applicant._id)
+                id: applicant._id.toString()
             }
         }
 

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -31,7 +31,7 @@ import { s3Client, BUCKET_NAME } from '../clients/AWSClient/S3Client';
 import { GetObjectCommand, PutObjectCommand, CopyObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
-import { sanitizeUserFullName, validateTeamName, capitalizeString } from '../utils/strings';
+import { sanitizeUserFullName, validateTeamName, capitalizeString, validatePersonName } from '../utils/strings';
 import { BindleController, EnabledBindlePermissions } from '../controllers/BindleController';
 import { AuthorizedUser } from '../clients/OpenIdClient';
 import { executiveAuthVerify } from '../auth';
@@ -613,8 +613,9 @@ export class OrgController extends Controller {
         @Request() req: express.Request | ExpressRequestAuthUserShim & ExpressRequestBindleShim,
         @Body() inviteReq: APITeamInviteCreateRequest
     ) {
-        /* Sanitize Request */
-        inviteReq.inviteeName = capitalizeString(inviteReq.inviteeName);
+        /* Validate & Normalize Name */
+        const cleanedName = validatePersonName(inviteReq.inviteeName);
+        inviteReq.inviteeName = capitalizeString(cleanedName);
 
         /* Check if Email is in Supported Domain */
         if (!inviteReq.inviteeEmail.endsWith("@terpmail.umd.edu")) {

--- a/src/models/Invites.ts
+++ b/src/models/Invites.ts
@@ -31,7 +31,10 @@ export interface IInvite extends Document {
 const inviteSchema = new Schema<IInvite>({
   inviteName: {
     type: String,
-    required: true
+    required: true,
+    minlength: [2, 'Name must be at least 2 characters'],
+    maxlength: [60, 'Name must be at most 60 characters'],
+    match: [/^[A-Za-z .'-]+$/, "Invalid name. Use only letters, spaces, apostrophes, periods, and hyphens."]
   },
   inviteEmail: {
     type: String,

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -103,11 +103,6 @@ export function validatePersonName(name: string): string {
     );
   }
 
-  // Ensure at least one letter exists
-  if (!/[A-Za-z]/.test(trimmed)) {
-    throw new CustomValidationError(400, 'Invalid name. Must contain at least one letter.');
-  }
-
   // Enforce presence of first and last name (at least two name parts with letters)
   // Example valid: "Jane Doe", "Mary-Kate O'Neil", "J. Smith"
   const parts = trimmed.split(/\s+/).filter(p => p.length > 0);

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -77,6 +77,49 @@ export function sanitizeUserFullName(fullName: string): string {
 }
 
 /**
+ * Validates a human full name coming from the frontend.
+ * - Trims whitespace
+ * - Enforces length between 2 and 60 characters
+ * - Allows letters, spaces, apostrophes, periods, and hyphens
+ * - Must contain at least one letter
+ * Returns the trimmed name if valid; throws CustomValidationError otherwise.
+ */
+export function validatePersonName(name: string): string {
+  const trimmed = (name ?? '').trim();
+
+  if (trimmed.length < 2 || trimmed.length > 60) {
+    throw new CustomValidationError(
+      400,
+      'Invalid name. Must be between 2 and 60 characters.'
+    );
+  }
+
+  // Allow letters in any case, spaces, apostrophes, periods, and hyphens
+  const allowed = /^[A-Za-z .'-]+$/;
+  if (!allowed.test(trimmed)) {
+    throw new CustomValidationError(
+      400,
+      "Invalid name. Use only letters, spaces, apostrophes, periods, and hyphens."
+    );
+  }
+
+  // Ensure at least one letter exists
+  if (!/[A-Za-z]/.test(trimmed)) {
+    throw new CustomValidationError(400, 'Invalid name. Must contain at least one letter.');
+  }
+
+  // Enforce presence of first and last name (at least two name parts with letters)
+  // Example valid: "Jane Doe", "Mary-Kate O'Neil", "J. Smith"
+  const parts = trimmed.split(/\s+/).filter(p => p.length > 0);
+  const alphaParts = parts.filter(p => /[A-Za-z]/.test(p));
+  if (alphaParts.length < 2) {
+    throw new CustomValidationError(400, 'Please enter a first and last name.');
+  }
+
+  return trimmed;
+}
+
+/**
  * Formats a bindle access error message listing team owners and missing bindles.
  */
 export function formatBindleAccessError(owners: string[], missingBindles: string[]): string {


### PR DESCRIPTION
  ## Summary
  - Added a small Redis client wrapper with `get`, `set`, and `delete` helpers.
  - Initialized Redis when the backend server starts.
  - Cached the result of `GET /api/ats/openteams` under `ats:openteams`.
  - Invalidated the `ats:openteams` cache when a subteam is added to or removed
  from recruiting.

  ## Testing
  - Ran `npm run build` successfully.
  - Started the backend locally with Redis running in Docker.
  - Created/updated recruiting settings for the Leadership subteam under Test Team.
  - Confirmed `GET /api/ats/openteams` populated Redis with the `ats:openteams`
  key.
  - Checked the cached value with `redis-cli GET ats:openteams` and verified it
  included Test Team, Leadership, the `SWE` role, and the recruiting question.
  - Turned recruiting off for the Leadership subteam and confirmed the Redis cache
  was invalidated.
  - Called `GET /api/ats/openteams` again and confirmed the cache was rebuilt with
  the fresh response.
